### PR TITLE
Safe eval

### DIFF
--- a/spinn_utilities/safe_eval.py
+++ b/spinn_utilities/safe_eval.py
@@ -9,22 +9,3 @@ class SafeEval(object):
 
     def eval(self, expression, **kwargs):
         return eval(expression, self._environment, kwargs)
-
-
-if __name__ == "__main__":
-    def Abc(x):
-        return x+1
-    def Def(x):
-        return x*2
-    def Ghi(x):
-        return x*0.5
-
-    evaluator = SafeEval(Abc, Def)
-    def test(string, **args):
-        try:
-            result = evaluator.eval(string, **args)
-            print string, "=", result
-        except NameError:
-            print "failed to evaluate", string
-    test("Def(Abc(x))", x=3)
-    test("Ghi(Def(Abc(y)))", y=3)

--- a/spinn_utilities/safe_eval.py
+++ b/spinn_utilities/safe_eval.py
@@ -1,0 +1,30 @@
+class SafeEval(object):
+    __slots__ = ["_environment"]
+
+    def __init__(self, *args):
+        env = {}
+        for item in args:
+            env[item.__name__] = item
+        self._environment = env
+
+    def eval(self, expression, **kwargs):
+        return eval(expression, self._environment, kwargs)
+
+
+if __name__ == "__main__":
+    def Abc(x):
+        return x+1
+    def Def(x):
+        return x*2
+    def Ghi(x):
+        return x*0.5
+
+    evaluator = SafeEval(Abc, Def)
+    def test(string, **args):
+        try:
+            result = evaluator.eval(string, **args)
+            print string, "=", result
+        except NameError:
+            print "failed to evaluate", string
+    test("Def(Abc(x))", x=3)
+    test("Ghi(Def(Abc(y)))", y=3)

--- a/spinn_utilities/safe_eval.py
+++ b/spinn_utilities/safe_eval.py
@@ -1,11 +1,45 @@
 class SafeEval(object):
+    """This provides expression evaluation capabilities while allowing the set
+    of symbols exposed to the expression to be strictly controlled.
+
+    Sample of use:
+
+    >>> import math
+    >>> def evil_func(x):
+           print "HAHA!"
+           return x/0.0
+
+    >>> eval_safely = SafeEval(math)
+    >>> eval_safely.eval("math.sqrt(x)", x=1.23)
+    1.1090536506409416
+    >>> eval_safely.eval("evil_func(1.23)")
+    Traceback (most recent call last):
+      ...
+    NameError: name 'evil_func' is not defined
+    """
     __slots__ = ["_environment"]
 
     def __init__(self, *args):
+        """
+        :param args: The symbols to use to populate the global reference table.
+        Note that all of these symbols must support the __name__ property, but
+        that includes any function, method of an object, or module. If you want
+        to make an object available by anything other than its inherent name,
+        define it in the eval() call.
+        """
         env = {}
         for item in args:
             env[item.__name__] = item
         self._environment = env
 
     def eval(self, expression, **kwargs):
+        """Evaluate an expression and return the result.
+
+        :param expression: The expression to evaluate
+        :type expression: str
+        :param kwargs: The extra symbol bindings to use for this evaluation.
+        This is useful for passing in particular parameters to an individual
+        evaluation run.
+        :return: The expression result
+        """
         return eval(expression, self._environment, kwargs)

--- a/unittests/test_safe_eval.py
+++ b/unittests/test_safe_eval.py
@@ -27,6 +27,7 @@ def test_simple_eval():
     assert evaluator.eval("1+2*3") == 7
     assert evaluator.eval("x+y*z", x=1, y=2, z=3) == 7
 
+
 def test_environment_eval():
     evaluator = SafeEval(Abc)
     assert evaluator.eval("Abc(1)") == 2
@@ -34,6 +35,7 @@ def test_environment_eval():
         evaluator.eval("Def(1)")
     with pytest.raises(TypeError):
         evaluator.eval("Abc(1,2)")
+
 
 def test_multi_environment():
     s = Support()

--- a/unittests/test_safe_eval.py
+++ b/unittests/test_safe_eval.py
@@ -1,0 +1,59 @@
+from spinn_utilities.safe_eval import SafeEval
+import pytest
+import math
+
+
+def Abc(x):
+    return x+1
+
+
+class Support(object):
+    def __init__(self):
+        self._c = 0
+
+    def Def(self, x):
+        return x*2
+
+    def Ghi(self, x):
+        return x*0.5
+
+    def Jkl(self, x):
+        self._c += 1
+        return x + self._c**2
+
+
+def test_simple_eval():
+    evaluator = SafeEval()
+    assert evaluator.eval("1+2*3") == 7
+    assert evaluator.eval("x+y*z", x=1, y=2, z=3) == 7
+
+def test_environment_eval():
+    evaluator = SafeEval(Abc)
+    assert evaluator.eval("Abc(1)") == 2
+    with pytest.raises(NameError):
+        evaluator.eval("Def(1)")
+    with pytest.raises(TypeError):
+        evaluator.eval("Abc(1,2)")
+
+def test_multi_environment():
+    s = Support()
+    evaluator = SafeEval(Abc, s.Def)
+    assert evaluator.eval("x+y*z", x=1, y=2, z=3) == 7
+    assert evaluator.eval("Def(Abc(x))", x=3) == 8
+    with pytest.raises(NameError):
+        assert evaluator.eval("Ghi(Def(Abc(y)))", y=3) == 1
+    assert evaluator.eval("Ghi(Def(Abc(y)))", y=3, Ghi=s.Ghi) == 4.0
+    assert evaluator.eval("Ghi(Def(Abc(y)))", y=3, Ghi=s.Def) == 16
+    # Not sure if the next test should pass; Python, huh...
+    assert evaluator.eval("Ghi.__name__", y=3, Ghi=s.Def) == "Def"
+
+
+def test_state_sensitive():
+    s = Support()
+    evaluator = SafeEval(s.Jkl)
+    assert evaluator.eval("Jkl(Jkl(Jkl(x)))", x=2.5) == 16.5
+
+
+def test_packages():
+    evaluator = SafeEval(math)
+    assert evaluator.eval("math.floor(d)", d=2.5) == 2.0


### PR DESCRIPTION
This is the core of how to de-fang the code in SpyNNaker that makes people nauseous when they look at it: `spynnaker.pyNN.models.neural_projections.connectors.distance_dependent_probability_connector`

That code will still not be great even with the help of this class, but at least its pollution can be contained (and we can use it in the other places we use `eval()` a bit too directly too).