### PR TITLE
Safe eval extra defs

### DIFF
--- a/spinn_utilities/safe_eval.py
+++ b/spinn_utilities/safe_eval.py
@@ -19,7 +19,7 @@ class SafeEval(object):
     """
     __slots__ = ["_environment"]
 
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
         """
         :param args:\
             The symbols to use to populate the global reference table.
@@ -27,10 +27,15 @@ class SafeEval(object):
             but that includes any function, method of an object, or module. If\
             you want to make an object available by anything other than its\
             inherent name, define it in the eval() call.
+        :param kwargs:\
+            Define the symbols with explicit names. Needed because some\
+            symbols (e.g., constants in numpy) do not have names that we can\
+            otherwise look up easily.
         """
         env = {}
         for item in args:
             env[item.__name__] = item
+        env.update(kwargs)
         self._environment = env
 
     def eval(self, expression, **kwargs):

--- a/unittests/test_safe_eval.py
+++ b/unittests/test_safe_eval.py
@@ -59,3 +59,8 @@ def test_state_sensitive():
 def test_packages():
     evaluator = SafeEval(math)
     assert evaluator.eval("math.floor(d)", d=2.5) == 2.0
+
+
+def test_defined_names():
+    evaluator = SafeEval(math, x=123.25)
+    assert evaluator.eval("math.floor(x+d)", d=0.875) == 124.0


### PR DESCRIPTION
Needed extra capability to define names for things without intrinsic names. Needed because `numpy.pi` and `numpi.e` are plain floats.