### PR TITLE
allows default behaviour to be old progress bar

### DIFF
--- a/spinn_utilities/progress_bar.py
+++ b/spinn_utilities/progress_bar.py
@@ -35,7 +35,7 @@ class ProgressBar(object):
 
         # Determine if we are in a "bad" terminal i.e. one that doesn't handle
         # carriage return correctly
-        self._in_bad_terminal = "PROGRESS_BAD_TERMINAL" in os.environ
+        self._in_bad_terminal = "PROGRESS_GOOD_TERMINAL" not in os.environ
 
         self._create_initial_progress_bar(
             string_describing_what_being_progressed)


### PR DESCRIPTION
This is to avoid all the faff by default of the new progress bar. Otherwise we need to change portal, end users with ides etc. This at least means you only get the new process bar if you want it.