### PR TITLE
Executable finder improvement

### DIFF
--- a/spinn_utilities/executable_finder.py
+++ b/spinn_utilities/executable_finder.py
@@ -28,8 +28,7 @@ class ExecutableFinder(object):
         :return: Nothing is returned
         :rtype: None
         """
-        if path not in self._path_set:
-            self._binary_search_paths.add(path)
+        self._binary_search_paths.add(path)
 
     @property
     def binary_paths(self):

--- a/spinn_utilities/executable_finder.py
+++ b/spinn_utilities/executable_finder.py
@@ -1,4 +1,5 @@
 import os
+from .ordered_set import OrderedSet
 
 
 class ExecutableFinder(object):
@@ -13,7 +14,9 @@ class ExecutableFinder(object):
             The initial set of folders to search for binaries.
         :type binary_search_paths: iterable of str
         """
-        self._binary_search_paths = binary_search_paths
+        self._binary_search_paths = OrderedSet()
+        for path in binary_search_paths:
+            self.add_path(path)
 
     def add_path(self, path):
         """ Adds a path to the set of folders to be searched.  The path is\
@@ -25,7 +28,8 @@ class ExecutableFinder(object):
         :return: Nothing is returned
         :rtype: None
         """
-        self._binary_search_paths.append(path)
+        if path not in self._path_set:
+            self._binary_search_paths.add(path)
 
     @property
     def binary_paths(self):

--- a/unittests/test_exec_finder.py
+++ b/unittests/test_exec_finder.py
@@ -40,3 +40,19 @@ def test_find_in_two_places(tmpdir):
     assert ef.get_executable_path("abc.aplx") == str(w1)
     w1.remove()
     assert ef.get_executable_path("abc.aplx") is None
+
+
+def test_find_no_duplicates(tmpdir):
+    a = tmpdir.mkdir("a")
+    b = tmpdir.mkdir("b")
+    ef = ExecutableFinder([str(a), str(b)])
+    assert ef.binary_paths == "{} : {}".format(a, b)
+    ef.add_path(str(a))
+    ef.add_path(str(a))
+    ef.add_path(str(b))
+    ef.add_path(str(b))
+    ef.add_path(str(a))
+    ef.add_path(str(a))
+    ef.add_path(str(b))
+    ef.add_path(str(b))
+    assert ef.binary_paths == "{} : {}".format(a, b)


### PR DESCRIPTION
The internal model of the executable finder should be an ordered set. Make it one.