### PR TITLE
read in machine_spec_file directly after config which specifies it

### DIFF
--- a/unittests/test_conf_loader.py
+++ b/unittests/test_conf_loader.py
@@ -61,8 +61,7 @@ def test_intermediate_use(tmpdir, default_config, mach_spec):
             assert config.sections() == ["sect", "Machine"]
             assert config.options("sect") == ["foo"]
             assert config.get("sect", "foo") == "bar"
-            assert config.options("Machine") == ["machine_spec_file",
-                                                 "machinename", "version"]
+            assert config.options("Machine") == ["machinename", "version"]
             assert config.get("Machine", "MachineName") == "foo"
             assert config.getint("Machine", "VeRsIoN") == 5
             log_checker.assert_logs_info_contains(l.records, CFGFILE)


### PR DESCRIPTION
Previously only the last machine_spec was read in and AFTER even the config in the run directory.

Therefor a machine spec file had a higher preference to the config in the run directory.

Now each time a config file is read in the machine spec file if specified is read at that point.
So there could be multiple machine speci files
Higher preference config files are not ovewritten