### PR TITLE
More config capabilities

### DIFF
--- a/spinn_utilities/conf_loader.py
+++ b/spinn_utilities/conf_loader.py
@@ -268,6 +268,7 @@ class _ExtendedConfigParser(RawConfigParser):
 @add_metaclass(AbstractBase)
 class ConfigParserCallback(object):
     __slots__ = []
+
     @abstractmethod
     def __call__(self, config):
         """Parse a section of the config. The configuration can be updated \


### PR DESCRIPTION
Add the read-typed-values capabilities to the configs generated by the config loader, instead of scattering them through various utility functions.