### PR TITLE
Importing the util module directly

### DIFF
--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -1,5 +1,5 @@
 from ConfigParser import RawConfigParser
-import distutils
+import distutils.util
 
 
 class CamelCaseConfigParser(RawConfigParser):


### PR DESCRIPTION
If the import is done on the module, it doesn't always let you get at the submodule.  Importing the submodule makes it work.