### PR TITLE
Use @overrides much more within the ranged dict code

### DIFF
--- a/spinn_utilities/overrides.py
+++ b/spinn_utilities/overrides.py
@@ -14,14 +14,15 @@ class overrides(object):
         # True if the doc string is to be extended, False to set if not set
         "_extend_doc",
         # Any additional arguments required by the subclass method
-        "_additional_arguments"
+        "_additional_arguments",
+        # True if the subclass method may have additional defaults
+        "_extend_defaults"
     ]
 
     def __init__(
             self, super_class_method, extend_doc=True,
-            additional_arguments=None):
+            additional_arguments=None, extend_defaults=False):
         """
-
         :param super_class_method: The method to override in the superclass
         :param extend_doc:\
             True the method doc string should be appended to the super-method\
@@ -30,21 +31,26 @@ class overrides(object):
         :param additional_arguments:\
             Additional arguments taken by the subclass method over the\
             superclass method, e.g., that are to be injected
+        :param extend_defaults: \
+            Whether the subclass may specify extra defaults for the parameters
         """
         self._superclass_method = super_class_method
         self._extend_doc = extend_doc
         self._additional_arguments = additional_arguments
+        self._extend_defaults = extend_defaults
         if additional_arguments is None:
             self._additional_arguments = {}
         if isinstance(super_class_method, property):
             self._superclass_method = super_class_method.fget
 
     @staticmethod
-    def __match_defaults(default_args, super_defaults):
+    def __match_defaults(default_args, super_defaults, extend_ok):
         if default_args is None:
             return super_defaults is None
         elif super_defaults is None:
-            return False
+            return extend_ok
+        if extend_ok:
+            return len(default_args) >= len(super_defaults)
         return len(default_args) == len(super_defaults)
 
     def __verify_method_arguments(self, method):
@@ -68,7 +74,8 @@ class overrides(object):
             if arg != super_arg:
                 raise AttributeError(
                     "Missing argument {}".format(super_arg))
-        if not self.__match_defaults(default_args, super_args.defaults):
+        if not self.__match_defaults(
+                default_args, super_args.defaults, self._extend_defaults):
             raise AttributeError(
                 "Default arguments don't match super class method")
 
@@ -99,6 +106,5 @@ class overrides(object):
         elif (self._extend_doc and
                 self._superclass_method.__doc__ is not None):
             method.__doc__ = (
-                self._superclass_method.__doc__ +
-                method.__doc__)
+                self._superclass_method.__doc__ + method.__doc__)
         return method

--- a/spinn_utilities/ranged/abstract_dict.py
+++ b/spinn_utilities/ranged/abstract_dict.py
@@ -24,7 +24,6 @@ class AbstractDict(object):
             If even one of the keys has multiple values set.\
             But not if other keys not asked for have multiple values
         """
-        pass
 
     @abstractmethod
     def keys(self):
@@ -32,7 +31,6 @@ class AbstractDict(object):
 
         :return: keys in the dict
         """
-        pass
 
     @abstractmethod
     def set_value(self, key, value):
@@ -54,7 +52,6 @@ class AbstractDict(object):
         :param value: any object
         :raise KeyError: If a new key is being used.
         """
-        pass
 
     @abstractmethod
     def ids(self):
@@ -71,7 +68,6 @@ class AbstractDict(object):
         :return: list of IDs
         :rtype: list(int)
         """
-        pass
 
     @abstractmethod
     def iter_all_values(self, key, update_save=False):
@@ -90,7 +86,6 @@ class AbstractDict(object):
             If key is iterable (list, tuple, set, etc) of str (or None)\
             yields dictionary objects
         """
-        pass
 
     def get_ranges(self, key=None):
         """ Lists the ranges(s) for all IDs covered by this view
@@ -134,7 +129,6 @@ class AbstractDict(object):
             If key is iterable (list, tuple, set, etc) of str (or None)\
             value is a dictionary object
         """
-        pass
 
     @abstractmethod
     def get_default(self, key):
@@ -150,7 +144,6 @@ class AbstractDict(object):
         :type key: str
         :return: default for this key.
         """
-        pass
 
     def items(self):
         """ Returns a list of (key, value) tuples

--- a/spinn_utilities/ranged/abstract_sized.py
+++ b/spinn_utilities/ranged/abstract_sized.py
@@ -3,8 +3,7 @@ import sys
 
 
 class AbstractSized(object):
-    """
-    Base class for slice and id checking against size.
+    """ Base class for slice and ID checking against size.
     """
 
     __slots__ = [
@@ -24,14 +23,19 @@ class AbstractSized(object):
         """
         return self._size
 
+    @staticmethod
+    def _is_id_type(id):  # @ReservedAssignment
+        """ Check if the given ID has a type acceptable for IDs. """
+        return isinstance(id, (int, long))
+
     def _check_id_in_range(self, id):  # @ReservedAssignment
         if id < 0:
-            if isinstance(id, (int, long)):
+            if self._is_id_type(id):
                 raise IndexError(
                     "The index {} is out of range.".format(id))
             raise TypeError("Invalid argument type {}.".format(type(id)))
         if id >= self._size:
-            if isinstance(id, (int, long)):
+            if self._is_id_type(id):
                 raise IndexError(
                     "The index {0!d} is out of range.".format(id))
             raise TypeError("Invalid argument type {}.".format(type(id)))
@@ -42,7 +46,7 @@ class AbstractSized(object):
         elif slice_start < 0:
             slice_start = self._size + slice_start
             if slice_start < 0:
-                if isinstance(slice_start, (int, long)):
+                if self._is_id_type(slice_start):
                     raise IndexError(
                         "The range_start {} is out of range.".format(
                             slice_start))
@@ -53,17 +57,17 @@ class AbstractSized(object):
         elif slice_stop < 0:
             slice_stop = self._size + slice_stop
         if slice_start > slice_stop:
-            if not isinstance(slice_start, (int, long)):
+            if not self._is_id_type(slice_start):
                 raise TypeError("Invalid argument type {}.".format(
                     type(slice_start)))
-            if not isinstance(slice_stop, (int, long)):
+            if not self._is_id_type(slice_stop):
                 raise TypeError("Invalid argument type {}.".format(
                     type(slice_start)))
             raise IndexError(
                 "The range_start {} is after the range stop {}.".format(
                     slice_start, slice_stop))
         if slice_stop > len(self):
-            if isinstance(slice_stop, (int, long)):
+            if self._is_id_type(slice_stop):
                 raise IndexError("The range_stop {} is out of range.".format(
                     slice_stop))
             raise TypeError("Invalid argument type {}.".format(

--- a/spinn_utilities/ranged/abstract_view.py
+++ b/spinn_utilities/ranged/abstract_view.py
@@ -1,4 +1,5 @@
 from spinn_utilities.ranged.abstract_dict import AbstractDict
+from spinn_utilities.overrides import overrides
 
 
 class AbstractView(AbstractDict):
@@ -6,25 +7,23 @@ class AbstractView(AbstractDict):
         "_range_dict"]
 
     def __init__(self, range_dict):
-        """
-        USE RangeDictionary.view_factory to create views
+        """ Use :py:meth:`RangeDictionary.view_factory` to create views
         """
         self._range_dict = range_dict
 
     def __getitem__(self, key):
-        """
-        Support for the view[x] based the type of the key
+        """ Support for the view[x] based the type of the key
 
         key is a str is currently not supported use get_value instead. \
         In the future this may be supported to return some kind of list\
         (AbstractList) but how to handle a view there to be determined
 
         For int and int collections a new view will be returned using\
-        RangeDictionary.view_factory
+        :py:meth:`RangeDictionary.view_factory`
 
         .. note::
-            int are indexes into the list of ids not id values\
-            So for a view with ids [2,3,4,5] view[2] will have an id of 4
+            int are indexes into the list of IDs not ID values\
+            So for a view with IDs [2,3,4,5] view[2] will have an ID of 4
 
         :param key: str, int or collection of int
         :return: the single value for the str key or a view
@@ -42,12 +41,11 @@ class AbstractView(AbstractDict):
         return self._range_dict.view_factory(selected)
 
     def __setitem__(self, key, value):
-        """ See AbstractDict.set_value
+        """ See :py:meth:`AbstractDict.set_value`
 
         .. note::
-            Unlike __getitem__ int based ids are NOT supported so\
-            view[int] == will raise and exception
-
+            Unlike ``__getitem__``, int based IDs are *not* supported so\
+            ``view[int] ==`` will raise an exception
         """
         if isinstance(key, str):
             return self.set_value(key=key, value=value)
@@ -58,8 +56,10 @@ class AbstractView(AbstractDict):
     def viewkeys(self):
         return self._range_dict.viewkeys()
 
+    @overrides(AbstractDict.get_default)
     def get_default(self, key):
         self._range_dict.get_default(key)
 
+    @overrides(AbstractDict.keys)
     def keys(self):
         return self._range_dict.keys()

--- a/spinn_utilities/ranged/ids_view.py
+++ b/spinn_utilities/ranged/ids_view.py
@@ -1,4 +1,6 @@
 from spinn_utilities.ranged.abstract_view import AbstractView
+from spinn_utilities.overrides import overrides
+from spinn_utilities.ranged.abstract_dict import AbstractDict
 
 
 class _IdsView(AbstractView):
@@ -6,8 +8,7 @@ class _IdsView(AbstractView):
         "_ids"]
 
     def __init__(self, range_dict, ids):
-        """
-        USE RangeDictionary.view_factory to create views
+        """ Use :py:meth:`RangeDictionary.view_factory` to create views
         """
         super(_IdsView, self).__init__(range_dict)
         self._ids = ids
@@ -15,12 +16,15 @@ class _IdsView(AbstractView):
     def __str__(self):
         return "View with ids: {}".format(self._ids)
 
+    @overrides(AbstractDict.ids)
     def ids(self):
         return list(self._ids)
 
+    @overrides(AbstractDict.get_value)
     def get_value(self, key):
         return self._range_dict.get_list(key).get_value_by_ids(self._ids)
 
+    @overrides(AbstractDict.set_value)
     def set_value(self, key, value):
         ranged_list = self._range_dict.get_list(key)
         for _id in self._ids:
@@ -28,11 +32,13 @@ class _IdsView(AbstractView):
 
     def set_value_by_ids(self, key, ids, value):
         for _id in ids:
-            self._value_lists[key].set_value_id(id=_id, value=value)
+            self._range_dict[key].set_value_by_id(id=_id, value=value)
 
+    @overrides(AbstractDict.iter_all_values)
     def iter_all_values(self, key, update_save=False):
         return self._range_dict.iter_values_by_ids(
             ids=self._ids, key=key, update_save=update_save)
 
-    def iter_ranges(self, key):
+    @overrides(AbstractDict.iter_ranges)
+    def iter_ranges(self, key=None):
         return self._range_dict.iter_ranges_by_ids(key=key, ids=self._ids)

--- a/spinn_utilities/ranged/range_dictionary.py
+++ b/spinn_utilities/ranged/range_dictionary.py
@@ -6,11 +6,12 @@ from spinn_utilities.ranged.slice_view import _SliceView
 from spinn_utilities.ranged.ids_view import _IdsView
 from spinn_utilities.ranged.abstract_dict import AbstractDict
 from spinn_utilities.ranged.abstract_sized import AbstractSized
+from spinn_utilities.overrides import overrides
+from six import iteritems
 
 
 class RangeDictionary(AbstractSized, AbstractDict):
-    """
-    Main holding class for a range of similar Dictionary object.
+    """ Main holding class for a range of similar Dictionary object.
 
     Keys in the dictionary must be str object and can not be removed.
 
@@ -22,14 +23,13 @@ class RangeDictionary(AbstractSized, AbstractDict):
         "_value_lists"]
 
     def __init__(self, size, defaults=None):
-        """
-        Main constructor for a Ranged Dictionary
+        """ Main constructor for a Ranged Dictionary
 
-        The Object is set up initially where every id in the range will share\
+        The Object is set up initially where every ID in the range will share\
         the same value for each key. All keys must be of type str. The\
         default Values can be anything including None.
 
-        :param size: Fixed number of ids / Length of lists
+        :param size: Fixed number of IDs / Length of lists
         :type size: int
         :param defaults: Default dictionary where all keys must be str
         :type defaults: dict
@@ -37,13 +37,12 @@ class RangeDictionary(AbstractSized, AbstractDict):
         super(RangeDictionary, self).__init__(size)
         self._value_lists = dict()
         if defaults is not None:
-            for key, value in defaults.iteritems():
+            for key, value in iteritems(defaults):
                 self._value_lists[key] = self.list_factory(
                     size=size, value=value, key=key)
 
     def list_factory(self, size, value, key):
-        """
-        Defines which class or subclass of RangedList to use
+        """ Defines which class or subclass of RangedList to use
 
         Main purpose is for subclasses to use a subclass or RangedList.\
         All parameters are pass through ones to the List constructor
@@ -56,19 +55,18 @@ class RangeDictionary(AbstractSized, AbstractDict):
         return RangedList(size, value, key)
 
     def view_factory(self, key):
-        """
-        Main function for creating views.
+        """ Main function for creating views.
 
         This is the preferred way of creating new views as it checks\
         parameters and returns the most efficient view.
 
-        Note the __getitem__ methods called by Object[id] and similar defer\
-        to this method so are fine to use.
+        Note the ``__getitem__`` methods called by Object[id] and similar\
+        defer to this method so are fine to use.
 
-        The id(s) used are the actual ids in the Range and not indexes on\
-        the list of ids
+        The ID(s) used are the actual IDs in the Range and not indexes on\
+        the list of IDs
 
-        :param key: A single int id, a Slice object or an Iterable of int ids
+        :param key: A single int ID, a Slice object or an Iterable of int IDs
         :return: A view over the Range
         """
         # Key is an int - return single view
@@ -114,12 +112,11 @@ class RangeDictionary(AbstractSized, AbstractDict):
         return _IdsView(range_dict=self, ids=key)
 
     def __getitem__(self, key):
-        """
-        Support for the view[x] based the type of the key
+        """ Support for the view[x] based the type of the key
 
-        If key is a str a list type object of AbstractList is returned
+        If key is a str a list type object of ``AbstractList`` is returned
 
-        Otherwise a View (AbstractView) over part of the ids in the Dict is\
+        Otherwise a View (AbstractView) over part of the IDs in the Dict is\
         returned
 
         Multiple str object or None are not supported as keys here
@@ -131,10 +128,8 @@ class RangeDictionary(AbstractSized, AbstractDict):
             return self._value_lists[key]
         return self.view_factory(key=key)
 
+    @overrides(AbstractDict.get_value, extend_defaults=True)
     def get_value(self, key=None):
-        """
-        See AbstractDict
-        """
         if isinstance(key, str):
             return self._value_lists[key].get_value_all()
         if key is None:
@@ -145,12 +140,12 @@ class RangeDictionary(AbstractSized, AbstractDict):
         return results
 
     def get_values_by_id(self, key, id):  # @ReservedAssignment
-        """
-        Same as AbstractDict.get_value but limited to a single id
+        """ Same as :py:meth:`AbstractDict.get_value` but limited to a single\
+            ID
 
-        :param key: as AbstractDict.get_value
-        :param id: single int id
-        :return: See AbstractDict.get_value
+        :param key: as :py:meth:`AbstractDict.get_value`
+        :param id: single int ID
+        :return: See :py:meth:`AbstractDict.get_value`
         """
         if isinstance(key, str):
             return self._value_lists[key].get_value_by_id(id)
@@ -162,8 +157,7 @@ class RangeDictionary(AbstractSized, AbstractDict):
         return results
 
     def get_list(self, key):
-        """
-        Gets the storage unit for a single key.
+        """ Gets the storage unit for a single key.
 
         Mainly intended by Views to access the data for one key directly
 
@@ -174,17 +168,14 @@ class RangeDictionary(AbstractSized, AbstractDict):
         return self._value_lists[key]
 
     def update_safe_iter_all_values(self, key, ids):
-        """
-        Same as AbstractDict.iter_all_values \
-        but limited to a collection of ids and update safe
+        """ Same as :py:meth:`AbstractDict.iter_all_values` \
+        but limited to a collection of IDs and update safe
         """
         for id_value in ids:  # @ReservedAssignment
             yield self.get_values_by_id(key=key, id=id_value)
 
+    @overrides(AbstractDict.iter_all_values, extend_defaults=True)
     def iter_all_values(self, key=None, update_save=False):
-        """
-        See AbstractDict.iter_all_values
-        """
         if isinstance(key, str):
             if update_save:
                 return self._value_lists[key].iter()
@@ -197,9 +188,8 @@ class RangeDictionary(AbstractSized, AbstractDict):
 
     def iter_values_by_slice(
             self, slice_start, slice_stop, key=None, update_save=False):
-        """
-        Same as AbstractDict.iter_all_values \
-        but limited to a simple slice
+        """ Same as :py:meth:`AbstractDict.iter_all_values` \
+            but limited to a simple slice
         """
         if isinstance(key, str) and not update_save:
             return self._value_lists[key].iter_by_slice(
@@ -211,9 +201,8 @@ class RangeDictionary(AbstractSized, AbstractDict):
             slice_start=slice_start, slice_stop=slice_stop, key=key))
 
     def iter_values_by_ids(self, ids, key=None, update_save=False):
-        """
-        Same as AbstractDict.iter_all_values \
-        but limited to a simple slice
+        """ Same as :py:meth:`AbstractDict.iter_all_values` \
+            but limited to a simple slice
         """
         if update_save:
             return self.update_safe_iter_all_values(key, ids)
@@ -225,27 +214,25 @@ class RangeDictionary(AbstractSized, AbstractDict):
             for _ in xrange(start, stop):
                 yield value
 
+    @overrides(AbstractDict.set_value)
     def set_value(self, key, value):
-        """
-        see AbstractDict.set_value
-        """
         self._value_lists[key].set_value(value)
 
     def __setitem__(self, key, value):
-        """
-        Wrapper around set_value to support range["key"] =
+        """ Wrapper around set_value to support ``range["key"] =``
 
-        NOTE: range[int] = is not supported
+        .. note:
+            ``range[int] =`` is not supported
 
-        value can be a single object or None in\
+        ``value`` can be a single object or ``None`` in\
         which case every value in the list is set to that.
-        value can be a collection but\
+        ``value`` can be a collection but\
         then it must be exactly the size of all lists in this dictionary.
-        value can be an AbstractList
+        ``value`` can be an ``AbstractList``
 
         :param key: Existing or NEW str dictionary key
         :type key: str
-        :param value: List or value to create list based on
+        :param value: List or value to create list based on.
         :return:
         """
         if isinstance(key, str):
@@ -263,21 +250,24 @@ class RangeDictionary(AbstractSized, AbstractDict):
         else:
             raise KeyError("Unexpected key type: {}".format(type(key)))
 
+    @overrides(AbstractDict.ids)
     def ids(self):
-        """
-        Returns a list of the ids in this Range
+        """ Returns a list of the IDs in this Range
 
-        :return: a list of the ids in this Range
+        :return: a list of the IDs in this Range
         :rtype: list(int)
         """
         return range(self._size)
 
+    @overrides(AbstractDict.has_key)
     def has_key(self, key):
         return key in self._value_lists
 
+    @overrides(AbstractDict.keys)
     def keys(self):
         return self._value_lists.keys()
 
+    @overrides(AbstractDict.iterkeys)
     def iterkeys(self):
         return self._value_lists.iterkeys()
 
@@ -309,10 +299,8 @@ class RangeDictionary(AbstractSized, AbstractDict):
             stop = next_stop
             yield (start, stop, current)
 
+    @overrides(AbstractDict.iter_ranges)
     def iter_ranges(self, key=None):
-        """
-        See AbstractDict.iter_ranges
-        """
         if isinstance(key, str):
             return self._value_lists[key].iter_ranges()
         if key is None:
@@ -323,11 +311,10 @@ class RangeDictionary(AbstractSized, AbstractDict):
         return self._merge_ranges(ranges)
 
     def iter_ranges_by_id(self, key=None, id=None):  # @ReservedAssignment
-        """
-        Same AbstractDict.iter_ranges but limited to one id
+        """ Same as :py:meth:`AbstractDict.iter_ranges` but limited to one ID
 
-        :param key: see AbstractDict.iter_ranges param key
-        :param id: single id which is the actual id and not an index into ids
+        :param key: see :py:meth`AbstractDict.iter_ranges` parameter key
+        :param id: single ID which is the actual ID and not an index into IDs
         :type id: int
         """
         if isinstance(key, str):
@@ -340,18 +327,17 @@ class RangeDictionary(AbstractSized, AbstractDict):
         return self._merge_ranges(ranges)
 
     def iter_ranges_by_slice(self, key, slice_start, slice_stop):
-        """
-        Same AbstractDict.iter_ranges but limited to a simple slice
+        """ Same as :py:meth:`AbstractDict.iter_ranges` but limited to a\
+            simple slice.
 
-        slice_start and slice_stop are actual id values and\
-        not indexes into the ids.
-        They must also be actual values, so None, max_int, and\
-        negative numbers are not supported.
+        ``slice_start`` and ``slice_stop`` are actual ID values and not\
+        indexes into the IDs. They must also be actual values, so ``None``,\
+        ``max_int``, and negative numbers are not supported.
 
-        :param key: see AbstractDict.iter_ranges param key
-        :param slice_start: Inclusive i.e. first id
-        :param slice_stop:  Exclusive to last id + 1
-        :return: see AbstractDict.iter_ranges
+        :param key: see :py:meth:`AbstractDict.iter_ranges` parameter ``key``
+        :param slice_start: Inclusive i.e. first ID
+        :param slice_stop:  Exclusive to last ID + 1
+        :return: see :py:meth:`AbstractDict.iter_ranges`
         """
         if isinstance(key, str):
             return self._value_lists[key].iter_ranges_by_slice(
@@ -365,15 +351,15 @@ class RangeDictionary(AbstractSized, AbstractDict):
         return self._merge_ranges(ranges)
 
     def iter_ranges_by_ids(self, ids, key=None):
+        """ Same as :py:meth:`AbstractDict.iter_ranges` but limited to a\
+            collection of IDs
+
+        IDs are actual ID values and not indexes into the IDs
+
+        :param key: see :py:meth:`AbstractDict.iter_ranges` parameter ``key``
+        :param ids: Collection of IDs in the range
+        :return: see :py:meth:`AbstractDict.iter_ranges`
         """
-         Same AbstractDict.iter_ranges but limited to a collection of ids
-
-         ids are actual id values and not indexes into the ids
-
-         :param key: see AbstractDict.iter_ranges param key
-         :param ids: Collection of ids in the range
-         :return: see AbstractDict.iter_ranges
-         """
         if isinstance(key, str):
             return self._value_lists[key].iter_ranges_by_ids(ids=ids)
         if key is None:
@@ -388,11 +374,11 @@ class RangeDictionary(AbstractSized, AbstractDict):
         """ Sets the default value for a single key.
 
         .. note::
-            Does not change any values but only changes what reset_value\
+            Does not change any values but only changes what ``reset_value``\
             would do
 
         .. warning::
-            If called on a View it sets the default for the WHOLE range\
+            If called on a View it sets the default for the *whole* range\
             and not just the view.
 
         :param key: Existing dict key
@@ -401,8 +387,6 @@ class RangeDictionary(AbstractSized, AbstractDict):
         """
         self._value_lists[key].set_default(default)
 
+    @overrides(AbstractDict.get_default)
     def get_default(self, key):
-        """
-        See AbstractDict.get_default
-        """
         return self._value_lists[key].get_default()

--- a/spinn_utilities/ranged/ranged_list.py
+++ b/spinn_utilities/ranged/ranged_list.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-builtin
 from spinn_utilities.ranged.abstract_list import AbstractList
+from spinn_utilities.overrides import overrides
 from spinn_utilities.ranged.multiple_values_exception \
     import MultipleValuesException
 
@@ -7,14 +8,14 @@ from spinn_utilities.ranged.multiple_values_exception \
 def function_iterator(function, size, ids=None):
     """ Converts a function into an iterator based on size or ids
 
-    This so that the function can be used to create a list as in:
-        list(function_iterator(lambda x: x * 2 , 3, ids=[2, 4, 6)
+    This so that the function can be used to create a list as in::
 
+        list(function_iterator(lambda x: x * 2 , 3, ids=[2, 4, 6)
 
     :param function: A function with one integer paramter that returns a value
     :param size: The number of elements to put in the list. If used the
         function will be called with xrange(size). Ignored if ids provided
-    :param ids: A list of ids to call the function for or None to use the size.
+    :param ids: A list of IDs to call the function for or None to use the size.
     :type ids: list of int
     :return: a list of values
     """
@@ -29,8 +30,7 @@ class RangedList(AbstractList):
         "_default", "_key", "_ranged_based", "_ranges"]
 
     def __init__(self, size, value, key=None):
-        """
-        Constructor for a ranged list.
+        """ Constructor for a ranged list.
 
         :param size: Fixed length of the list
         :param value: value to given to all elements in the list
@@ -42,16 +42,12 @@ class RangedList(AbstractList):
             self._default = value
         self.set_value(value)
 
+    @overrides(AbstractList.range_based)
     def range_based(self):
         return self._ranged_based
 
+    @overrides(AbstractList.get_value_by_id)
     def get_value_by_id(self, id):  # @ReservedAssignment
-        """ Returns the value for one item in the list
-
-        :param id: One of the IDs of an element in the list
-        :type id: int
-        :return: The value of that element
-        """
         self._check_id_in_range(id)
 
         # If range based, find the range containing the value and return
@@ -66,17 +62,8 @@ class RangedList(AbstractList):
         # Non-range-based so just return the value
         return self._ranges[id]
 
+    @overrides(AbstractList.get_value_by_slice)
     def get_value_by_slice(self, slice_start, slice_stop):
-        """ If possible returns a single value shared by the whole slice list.
-
-         For multiple values use for x in list, iter(list) or list.iter,\
-         or one of the iter_ranges methods
-
-         :return: Value shared by all elements in the slice
-         :raises MultipleValuesException: \
-             If even one elements has a different value.\
-             Not thrown if elements outside of the slice have a different value
-         """
         slice_start, slice_stop = self._check_slice_in_range(
             slice_start, slice_stop)
 
@@ -119,18 +106,8 @@ class RangedList(AbstractList):
                 raise MultipleValuesException(self._key, result, _value)
         return result
 
+    @overrides(AbstractList.get_value_by_ids)
     def get_value_by_ids(self, ids):
-        """ If possible returns a single value shared by all the IDs.
-
-        For multiple values use for x in list, iter(list) or list.iter,\
-        or one of the iter_ranges methods
-
-        :return: Value shared by all elements with these IDs
-        :raises MultipleValuesException: If one element has a different value.\
-            Not thrown if elements outside of the IDs have a different value,\
-            even if these elements are between the ones pointed to by IDs
-        """
-
         # Take the first id, and then simply check all the others are the same
         # This works for both range-based and non-range-based
         result = self.get_value_by_id(ids[0])
@@ -156,14 +133,8 @@ class RangedList(AbstractList):
             for value in self._ranges:
                 yield value
 
+    @overrides(AbstractList.iter_by_slice)
     def iter_by_slice(self, slice_start, slice_stop):
-        """ Fast NOT update safe iterator of all elements in the slice
-
-        .. note::
-            Duplicate/Repeated elements are yielded for each ID
-
-        :return: yields each element one by one
-        """
         slice_start, slice_stop = self._check_slice_in_range(
             slice_start, slice_stop)
 
@@ -189,6 +160,7 @@ class RangedList(AbstractList):
             for value in self._ranges[slice_start: slice_stop]:
                 yield value
 
+    @overrides(AbstractList.iter_ranges)
     def iter_ranges(self):
         """ Fast NOT update safe iterator of the ranges
 
@@ -214,15 +186,8 @@ class RangedList(AbstractList):
                     previous_value = value
             yield (previous_start, current_start + 1, current_value)
 
+    @overrides(AbstractList.iter_ranges_by_slice)
     def iter_ranges_by_slice(self, slice_start, slice_stop):
-        """ Fast NOT update safe iterator of the ranges covered by this slice
-
-        .. note::
-            The start and stop of the range will be reduced to just the\
-            IDs inside the slice
-
-         :return: yields each range one by one
-         """
         slice_start, slice_stop = self._check_slice_in_range(
             slice_start, slice_stop)
 
@@ -513,6 +478,7 @@ class RangedList(AbstractList):
         """
         self._default = default
 
+    @overrides(AbstractList.get_default, extend_doc=False)
     def get_default(self):
         """ Returns the default value for this list
 

--- a/spinn_utilities/ranged/single_view.py
+++ b/spinn_utilities/ranged/single_view.py
@@ -1,5 +1,7 @@
 # pylint: disable=redefined-builtin
+from spinn_utilities.ranged.abstract_dict import AbstractDict
 from spinn_utilities.ranged.abstract_view import AbstractView
+from spinn_utilities.overrides import overrides
 
 
 class _SingleView(AbstractView):
@@ -7,8 +9,7 @@ class _SingleView(AbstractView):
         "_id"]
 
     def __init__(self, range_dict, id):  # @ReservedAssignment
-        """
-        USE RangeDictionary.view_factory to create views
+        """ Use :py:meth:`RangeDictionary.view_factory` to create views
         """
         # print "Single"
         super(_SingleView, self).__init__(range_dict)
@@ -17,21 +18,26 @@ class _SingleView(AbstractView):
     def __str__(self):
         return "View with id: {}".format(self._id)
 
+    @overrides(AbstractDict.ids)
     def ids(self):
         return [self._id]
 
+    @overrides(AbstractDict.get_value)
     def get_value(self, key):
         return self._range_dict.get_list(key).get_value_by_id(id=self._id)
 
+    @overrides(AbstractDict.iter_all_values)
     def iter_all_values(self, key, update_save=False):
         if isinstance(key, str):
             yield self._range_dict.get_list(key).get_value_by_id(id=self._id)
         else:
             yield self._range_dict.get_values_by_id(key=key, id=self._id)
 
+    @overrides(AbstractDict.set_value)
     def set_value(self, key, value):
         return self._range_dict.get_list(key).set_value_by_id(
             value=value, id=self._id)
 
+    @overrides(AbstractDict.iter_ranges)
     def iter_ranges(self, key=None):
         return self._range_dict.iter_ranges_by_id(key=key, id=self._id)

--- a/spinn_utilities/ranged/slice_view.py
+++ b/spinn_utilities/ranged/slice_view.py
@@ -1,5 +1,7 @@
 # pylint: disable=redefined-builtin
+from spinn_utilities.ranged.abstract_dict import AbstractDict
 from spinn_utilities.ranged.abstract_view import AbstractView
+from spinn_utilities.overrides import overrides
 
 
 class _SliceView(AbstractView):
@@ -7,8 +9,7 @@ class _SliceView(AbstractView):
         "_start", "_stop"]
 
     def __init__(self, range_dict, start, stop):
-        """
-        USE RangeDictionary.view_factory to create views
+        """ Use :py:meth:`RangeDictionary.view_factory` to create views
         """
         super(_SliceView, self).__init__(range_dict)
         self._start = start
@@ -17,9 +18,11 @@ class _SliceView(AbstractView):
     def __str__(self):
         return "View with range: {} to {}".format(self._start, self._stop)
 
+    @overrides(AbstractDict.ids)
     def ids(self):
         return range(self._start, self._stop)
 
+    @overrides(AbstractDict.get_value)
     def get_value(self, key):
         return self._range_dict.get_list(key).get_value_by_slice(
             slice_start=self._start, slice_stop=self._stop)
@@ -29,6 +32,7 @@ class _SliceView(AbstractView):
         for id in self.ids():  # @ReservedAssignment
             yield ranged_list.get_value_by_id(id=id)
 
+    @overrides(AbstractDict.iter_all_values)
     def iter_all_values(self, key, update_save=False):
         if isinstance(key, str):
             if update_save:
@@ -39,10 +43,12 @@ class _SliceView(AbstractView):
             key=key, slice_start=self._start, slice_stop=self._stop,
             update_save=update_save)
 
+    @overrides(AbstractDict.set_value)
     def set_value(self, key, value):
         self._range_dict.get_list(key).set_value_by_slice(
             slice_start=self._start, slice_stop=self._stop, value=value)
 
+    @overrides(AbstractDict.iter_ranges)
     def iter_ranges(self, key=None):
         return self._range_dict.iter_ranges_by_slice(
             key=key, slice_start=self._start, slice_stop=self._stop)

--- a/unittests/test_overrides.py
+++ b/unittests/test_overrides.py
@@ -133,6 +133,14 @@ def test_defaults_super_param():
     # TODO: Should this case fail at all?
 
 
+def test_defaults_super_param_expected():
+    class Sub(Base):
+        @overrides(Base.foodef, extend_defaults=True)
+        def foodef(self, x, y=1, z=2):
+            return [z, y, x]
+    assert Sub().foodef(7) == [2, 1, 7]
+
+
 def test_defaults_extra_param():
     with pytest.raises(AttributeError) as e:
         class Sub(Base):


### PR DESCRIPTION
I noticed that the ranged dictionaries weren't using `@overrides` much, yet it's a bit important because it ensures that arguments are matched up properly (and documents why a particular method has been written). It also has the advantage of allowing a method's documentation string to be written only once (usually).

Had to extend the capabilities of `@overrides` to allow subclasses to say that they support more defaults. It's not permitted by default, but the optional `extend_defaults=True` turns on the greater laxity.

I may have also fixed some minor bugs along the way. Pay particular attention to `set_value_by_ids` in `ids_view.py`, which I think is correct now whereas I don't know why it could ever have worked before. (Pylint was not happy with it at all, FWIW.)