### PR TITLE
Create a dummy progress bar class.

### DIFF
--- a/spinn_utilities/progress_bar.py
+++ b/spinn_utilities/progress_bar.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 import sys
 import math
 import os
+from spinn_utilities.overrides import overrides
 
 
 class ProgressBar(object):
@@ -171,6 +172,31 @@ class ProgressBar(object):
         finally:
             if finish_at_end:
                 self.end()
+
+
+class DummyProgressBar(ProgressBar):
+    """ This is a dummy version of the progress bar that just stubs out the\
+        internal printing operations with code that does nothing. It otherwise\
+        fails in exactly the same way.
+    """
+    @overrides(ProgressBar._print_overwritten_line)
+    def _print_overwritten_line(self, string):
+        pass
+
+    @overrides(ProgressBar._print_distance_indicator)
+    def _print_distance_indicator(self, description):
+        pass
+
+    @overrides(ProgressBar._print_progress)
+    def _print_progress(self, length):
+        pass
+
+    @overrides(ProgressBar._print_progress_done)
+    def _print_progress_done(self):
+        pass
+
+    def __repr__(self):
+        return "<DummyProgressBar:{}>".format(self._string)
 
 
 if __name__ == "__main__":

--- a/spinn_utilities/progress_bar.py
+++ b/spinn_utilities/progress_bar.py
@@ -199,7 +199,7 @@ class DummyProgressBar(ProgressBar):
         return "<DummyProgressBar:{}>".format(self._string)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     from time import sleep
     demo = ProgressBar(
         5, "Progress Bar Demonstration", step_character="-", end_character="!")

--- a/unittests/test_progress_bar.py
+++ b/unittests/test_progress_bar.py
@@ -1,47 +1,53 @@
 import pytest
-from spinn_utilities.progress_bar import ProgressBar
+from spinn_utilities.progress_bar import ProgressBar, DummyProgressBar
 
 
-def test_operation():
-    p = ProgressBar(2, "abc")
+@pytest.mark.parametrize("pbclass", [ProgressBar, DummyProgressBar])
+def test_operation(pbclass):
+    p = pbclass(2, "abc")
     p.update()
     p.update()
     p.end()
 
 
-def test_two_end():
-    p = ProgressBar(2, "abc2")
+@pytest.mark.parametrize("pbclass", [ProgressBar, DummyProgressBar])
+def test_two_end(pbclass):
+    p = pbclass(2, "abc2")
     p.update()
     p.update()
     p.end()
     p.end()
 
 
-def test_with_operation():
-    with ProgressBar(2, "with_p") as p:
+@pytest.mark.parametrize("pbclass", [ProgressBar, DummyProgressBar])
+def test_with_operation(pbclass):
+    with pbclass(2, "with_p") as p:
         p.update()
         p.update()
 
 
-def test_check_length_full():
-    p = ProgressBar(2, None)
-    with pytest.raises(Exception):  # @UndefinedVariable
+@pytest.mark.parametrize("pbclass", [ProgressBar, DummyProgressBar])
+def test_check_length_full(pbclass):
+    p = pbclass(2, None)
+    with pytest.raises(Exception):
         p.update(3)
     p.end()
 
 
-def test_check_length_addition():
-    p = ProgressBar(2, None)
+@pytest.mark.parametrize("pbclass", [ProgressBar, DummyProgressBar])
+def test_check_length_addition(pbclass):
+    p = pbclass(2, None)
     p.update()
     p.update()
-    with pytest.raises(Exception):  # @UndefinedVariable
+    with pytest.raises(Exception):
         p.update()
     p.end()
 
 
-def test_iteration_style():
+@pytest.mark.parametrize("pbclass", [ProgressBar, DummyProgressBar])
+def test_iteration_style(pbclass):
     coll = range(5)
-    p = ProgressBar(coll, None)
+    p = pbclass(coll, None)
     total = 0
     for value in p.over(coll):
         total += value


### PR DESCRIPTION
This will allow us to keep code elsewhere much simpler by moving the decision of whether the progress bar actually prints anything into a single place in that code.