### PR TITLE
deprication fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ try:
 except ImportError:
     from distutils.core import setup
 try:
-    from collections.abc import MutableSet
+    from collections.abc import defaultdict
 except ImportError:
-    from collections import MutableSet
+    from collections import defaultdict
 import os
 
 __version__ = None

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-from collections import defaultdict
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
 import os
 
 __version__ = None

--- a/spinn_utilities/matrix/demo_matrix.py
+++ b/spinn_utilities/matrix/demo_matrix.py
@@ -1,4 +1,7 @@
-from collections import defaultdict
+try:
+    from collections.abc import defaultdict
+except ImportError:
+    from collections import defaultdict
 from spinn_utilities.overrides import overrides
 from .abstract_matrix import AbstractMatrix
 

--- a/spinn_utilities/ordered_set.py
+++ b/spinn_utilities/ordered_set.py
@@ -1,4 +1,7 @@
-from collections import MutableSet
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
 
 
 class _Node(object):


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated