### PR TITLE
Progress bar does not need to go boom boom just error.

### DIFF
--- a/spinn_utilities/logger_utils.py
+++ b/spinn_utilities/logger_utils.py
@@ -8,6 +8,13 @@ def warn_once(logger, msg):
     logger.warning(msg)
 
 
+def error_once(logger, msg):
+    if msg in _already_issued:
+        return
+    _already_issued.add(msg)
+    logger.error(msg)
+
+
 def reset():
     global _already_issued
     _already_issued = set()

--- a/spinn_utilities/progress_bar.py
+++ b/spinn_utilities/progress_bar.py
@@ -14,6 +14,9 @@ class ProgressBar(object):
     """
     MAX_LENGTH_IN_CHARS = 60
 
+    TOO_MANY_ERROR = "Too many update steps in progress bar! " \
+                     "This may be a sign that something else has gone wrong!"
+
     __slots__ = (
         "_number_of_things", "_currently_completed", "_destination",
         "_chars_per_thing", "_chars_done", "_string",
@@ -53,9 +56,7 @@ class ProgressBar(object):
         """
 
         if self._currently_completed + amount_to_add > self._number_of_things:
-            message = "Too many update steps in progress bar! " \
-                      "This may be a sign that something else has gone wrong!"
-            logger_utils.error_once(logger, message)
+            logger_utils.error_once(logger, self.TOO_MANY_ERROR)
             return
         self._currently_completed += amount_to_add
         self._check_differences()

--- a/spinn_utilities/progress_bar.py
+++ b/spinn_utilities/progress_bar.py
@@ -1,8 +1,12 @@
 from __future__ import print_function, division
+import logging
 import sys
 import math
 import os
 from spinn_utilities.overrides import overrides
+from spinn_utilities import logger_utils
+
+logger = logging.getLogger(__name__)
 
 
 class ProgressBar(object):
@@ -47,8 +51,12 @@ class ProgressBar(object):
         :param amount_to_add:
         :rtype: None
         """
+
         if self._currently_completed + amount_to_add > self._number_of_things:
-            raise Exception("too many update steps")
+            message = "Too many update steps in progress bar! " \
+                      "This may be a sign that something else has gone wrong!"
+            logger_utils.error_once(logger, message)
+            return
         self._currently_completed += amount_to_add
         self._check_differences()
 

--- a/unittests/test_logger_utils.py
+++ b/unittests/test_logger_utils.py
@@ -42,3 +42,13 @@ class TestLoggerUtils(unittest.TestCase):
             logger_utils.warn_once(logger, "a log warning")
             log_checker.assert_logs_contains_once("WARNING", lc.records,
                                                   "a log warning")
+
+    def test_error(self):
+        with LogCapture() as lc:
+            logger_utils.error_once(logger, "a log Error")
+            logger_utils.warn_once(logger, "another log error")
+            logger_utils.warn_once(logger, "a log warning")
+            log_checker.assert_logs_contains_once(
+                "ERROR", lc.records, "a log Error")
+            log_checker.assert_logs_error_not_contains(
+                lc.records, "another log error")

--- a/unittests/test_progress_bar.py
+++ b/unittests/test_progress_bar.py
@@ -1,5 +1,8 @@
 import pytest
+from testfixtures import LogCapture
 from spinn_utilities.progress_bar import ProgressBar, DummyProgressBar
+from spinn_utilities.testing import log_checker
+from spinn_utilities import logger_utils
 
 
 @pytest.mark.parametrize("pbclass", [ProgressBar, DummyProgressBar])
@@ -28,19 +31,25 @@ def test_with_operation(pbclass):
 
 @pytest.mark.parametrize("pbclass", [ProgressBar, DummyProgressBar])
 def test_check_length_full(pbclass):
+    logger_utils.reset()
     p = pbclass(2, None)
-    with pytest.raises(Exception):
+    with LogCapture() as lc:
         p.update(3)
+        log_checker.assert_logs_contains_once(
+            "ERROR", lc.records, ProgressBar.TOO_MANY_ERROR)
     p.end()
 
 
 @pytest.mark.parametrize("pbclass", [ProgressBar, DummyProgressBar])
 def test_check_length_addition(pbclass):
+    logger_utils.reset()
     p = pbclass(2, None)
     p.update()
     p.update()
-    with pytest.raises(Exception):
+    with LogCapture() as lc:
         p.update()
+        log_checker.assert_logs_contains_once(
+            "ERROR", lc.records, ProgressBar.TOO_MANY_ERROR)
     p.end()
 
 


### PR DESCRIPTION
Do we really need to kill the who run for a progress bar error.

True this could well be cause by something else going wrong which is why the log error level was used.