### PR TITLE
debug function as list

### DIFF
--- a/spinn_utilities/ordered_set.py
+++ b/spinn_utilities/ordered_set.py
@@ -135,3 +135,17 @@ class OrderedSet(MutableSet):
         :rtype: None
         """
         return not self.__eq__(other)
+
+    @property
+    def as_list(self):
+        """
+        Shows the sets as a list.
+
+        Main use is to allow debuggers easier access at the set.
+
+        Note: This list is disconnected so will not reflect any changes to the
+            original set.
+
+        :return: Set as a list
+        """
+        return list(self)


### PR DESCRIPTION
When looking at OrderedSets in a deugger it was hard to see their contents

This adds a property to show the contents as a list.

Probably only used in debugging but comes at a near zero cost when not used.