### PR TITLE
Smarter logger

### DIFF
--- a/spinn_utilities/log.py
+++ b/spinn_utilities/log.py
@@ -254,4 +254,3 @@ class FormatAdapter(logging.LoggerAdapter):
             key: kwargs[key]
             for key in getfullargspec(self.do_log).args[1:]
             if key in kwargs}
-

--- a/unittests/test_log.py
+++ b/unittests/test_log.py
@@ -48,6 +48,7 @@ class MockLog(object):
 def test_logger_adapter():
     log = MockLog()
     logger = FormatAdapter(log)
+    logger._repeat_log()  # clear the log
     logger.debug("Debug {}", "debug")
     assert log.last_level is None
     logger.info("Info {}", "info")
@@ -78,6 +79,7 @@ def test_logger_adapter():
 def test_logger_exception():
     log = MockLog()
     logger = FormatAdapter(log)
+    logger._repeat_log()  # clear the log
 
     class Exn(Exception):
         pass

--- a/unittests/test_log.py
+++ b/unittests/test_log.py
@@ -72,6 +72,7 @@ def test_logger_adapter():
         pass
     logger.set_kill_level()
     logger.critical("Should be ok now")
+    assert len(logger._repeat_log()) == 4
 
 
 def test_logger_exception():
@@ -91,3 +92,4 @@ def test_logger_exception():
     assert str(log.last_msg) == "ho"
     assert "exc_info" in log.last_kwargs
     assert log.last_level == logging.ERROR
+    assert len(logger._repeat_log()) == 1

--- a/unittests/test_log.py
+++ b/unittests/test_log.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from spinn_utilities.log import FormatAdapter
+from spinn_utilities.log import FormatAdapter, LogLevelTooHighException
 
 
 class MockLog(object):
@@ -64,6 +64,14 @@ def test_logger_adapter():
     logger.critical("bar")
     assert str(log.last_msg) == "bar"
     assert log.last_level == logging.CRITICAL
+    logger.set_kill_level(logging.CRITICAL)
+    try:
+        logger.critical("This is too high")
+        assert False
+    except LogLevelTooHighException:
+        pass
+    logger.set_kill_level()
+    logger.critical("Should be ok now")
 
 
 def test_logger_exception():


### PR DESCRIPTION
Extends the FormatAdapter with extra functionality,

Allow setting a kill level at which point any log it changed to an Exception.
Code to convert the log to an exception
By default the level is critical + 1 so never.

Cache all log messages of WARNING or higher.
Just before the python ends reprint these message to system.err

@dkfellows has done/ is doing work to ensure that wherever we log we use FormatAdapter on other branches.
