### PR TITLE
better timer.

### DIFF
--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -17,8 +17,8 @@ import sys
 
 if sys.version_info >= (3, 7):
     # acquire the most accurate measurement available (perf_counter_ns)
-    from time import perf_counter_ns as \
-        now  # pylint: disable=no-name-in-module
+    from time import \
+        perf_counter_ns as now  # pylint: disable=no-name-in-module
 
     # have to convert to a timedelta for rest of code to read
     from datetime import timedelta  # pylint: disable=no-name-in-module

--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys
 
-
+# pylint: disable=no-name-in-module
 if sys.version_info >= (3, 7):
     # acquire the most accurate measurement available (monotonic_ns)
     from time import monotonic_ns as now

--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -14,13 +14,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import sys
 
-# pylint: disable=no-name-in-module
+
 if sys.version_info >= (3, 7):
     # acquire the most accurate measurement available (monotonic_ns)
-    from time import monotonic_ns as now
+    from time import monotonic_ns as now # pylint: disable=no-name-in-module
 
     # have to convert to a timedelta for rest of code to read
-    from future.backports.datetime import timedelta
+    from future.backports.datetime import timedelta # pylint: disable=no-name-in-module
 
     # conversion factor
     NANO_TO_MICRO = 1000.0
@@ -31,10 +31,10 @@ if sys.version_info >= (3, 7):
         return timedelta(microseconds=time_diff / NANO_TO_MICRO)
 elif sys.version_info >= (3, 3):
     # acquire the most accurate measurement available (monotonic)
-    from time import monotonic as now
+    from time import monotonic as now # pylint: disable=no-name-in-module
 
     # have to convert to a timedelta for rest of code to read
-    from future.backports.datetime import timedelta
+    from future.backports.datetime import timedelta # pylint: disable=no-name-in-module
 
     # as montonic is fractional seconds, put into correct time delta
     def convert_to_timedelta(time_diff):

--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -17,10 +17,11 @@ import sys
 
 if sys.version_info >= (3, 7):
     # acquire the most accurate measurement available (monotonic_ns)
-    from time import monotonic_ns as now # pylint: disable=no-name-in-module
+    from time import monotonic_ns as now  # pylint: disable=no-name-in-module
 
     # have to convert to a timedelta for rest of code to read
-    from future.backports.datetime import timedelta # pylint: disable=no-name-in-module
+    from future.backports.datetime import \
+        timedelta  # pylint: disable=no-name-in-module
 
     # conversion factor
     NANO_TO_MICRO = 1000.0
@@ -31,10 +32,11 @@ if sys.version_info >= (3, 7):
         return timedelta(microseconds=time_diff / NANO_TO_MICRO)
 elif sys.version_info >= (3, 3):
     # acquire the most accurate measurement available (monotonic)
-    from time import monotonic as now # pylint: disable=no-name-in-module
+    from time import monotonic as now  # pylint: disable=no-name-in-module
 
     # have to convert to a timedelta for rest of code to read
-    from future.backports.datetime import timedelta # pylint: disable=no-name-in-module
+    from future.backports.datetime import \
+        timedelta  # pylint: disable=no-name-in-module
 
     # as montonic is fractional seconds, put into correct time delta
     def convert_to_timedelta(time_diff):

--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -17,7 +17,8 @@ import sys
 
 if sys.version_info >= (3, 7):
     # acquire the most accurate measurement available (perf_counter_ns)
-    from time import perf_counter_ns as now  # pylint: disable=no-name-in-module
+    from time import perf_counter_ns as \
+        now  # pylint: disable=no-name-in-module
 
     # have to convert to a timedelta for rest of code to read
     from datetime import timedelta  # pylint: disable=no-name-in-module

--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -17,11 +17,10 @@ import sys
 
 if sys.version_info >= (3, 7):
     # acquire the most accurate measurement available (monotonic_ns)
-    from time import monotonic_ns as now  # pylint: disable=no-name-in-module
+    from time import perf_counter_ns as now  # pylint: disable=no-name-in-module
 
     # have to convert to a timedelta for rest of code to read
-    from future.backports.datetime import \
-        timedelta  # pylint: disable=no-name-in-module
+    from datetime import timedelta  # pylint: disable=no-name-in-module
 
     # conversion factor
     NANO_TO_MICRO = 1000.0
@@ -30,13 +29,12 @@ if sys.version_info >= (3, 7):
     # need to convert
     def convert_to_timedelta(time_diff):
         return timedelta(microseconds=time_diff / NANO_TO_MICRO)
+
 elif sys.version_info >= (3, 3):
     # acquire the most accurate measurement available (monotonic)
-    from time import monotonic as now  # pylint: disable=no-name-in-module
-
+    from time import perf_counter as now  # pylint: disable=no-name-in-module
+    from datetime import timedelta  # pylint: disable=no-name-in-module
     # have to convert to a timedelta for rest of code to read
-    from future.backports.datetime import \
-        timedelta  # pylint: disable=no-name-in-module
 
     # as montonic is fractional seconds, put into correct time delta
     def convert_to_timedelta(time_diff):

--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -17,8 +17,8 @@ import sys
 
 if sys.version_info >= (3, 7):
     # acquire the most accurate measurement available (perf_counter_ns)
-    from time import \
-        perf_counter_ns as now  # pylint: disable=no-name-in-module
+    from time import (  # pylint: disable=no-name-in-module
+        perf_counter_ns as now)  # pylint: disable=no-name-in-module
 
     # have to convert to a timedelta for rest of code to read
     from datetime import timedelta  # pylint: disable=no-name-in-module

--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -16,7 +16,7 @@ import sys
 
 
 if sys.version_info >= (3, 7):
-    # acquire the most accurate measurement available (monotonic_ns)
+    # acquire the most accurate measurement available (perf_counter_ns)
     from time import perf_counter_ns as now  # pylint: disable=no-name-in-module
 
     # have to convert to a timedelta for rest of code to read
@@ -25,18 +25,18 @@ if sys.version_info >= (3, 7):
     # conversion factor
     NANO_TO_MICRO = 1000.0
 
-    # as montonic_ns is nano seconds, and time delta lowest is micro,
+    # as perf_counter_ns is nano seconds, and time delta lowest is micro,
     # need to convert
     def convert_to_timedelta(time_diff):
         return timedelta(microseconds=time_diff / NANO_TO_MICRO)
 
 elif sys.version_info >= (3, 3):
-    # acquire the most accurate measurement available (monotonic)
+    # acquire the most accurate measurement available (perf_counter)
     from time import perf_counter as now  # pylint: disable=no-name-in-module
     from datetime import timedelta  # pylint: disable=no-name-in-module
     # have to convert to a timedelta for rest of code to read
 
-    # as montonic is fractional seconds, put into correct time delta
+    # as perf_counter is fractional seconds, put into correct time delta
     def convert_to_timedelta(time_diff):
         return timedelta(seconds=time_diff)
 


### PR DESCRIPTION
this should in theory be compatible with all versions of python we support. and shouldn't be affected by server sync time.

picked up by timing paper showing discrepancies between progress bar and io time measurements. 