### PR TITLE
Upgrade Travis Ubuntu distribution to bionic (18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
         - 2.7
         - 3.6
         - 3.7
-dist: bionic
+dist: focal
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
         - 2.7
         - 3.6
         - 3.7
-dist: xenial
+dist: bionic
 addons:
   apt:
     packages:


### PR DESCRIPTION
Upgrading Travis Ubuntu distribution to 18.04 (bionic) to help us with binaries that are close to the ITCM limit.

See https://github.com/orgs/SpiNNakerManchester/projects/32 for full list of PRs.