### PR TITLE
Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,21 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 language: python
-python:
-        - 2.7
-        - 3.6
-        - 3.7
-dist: focal
+os: linux
+jobs:
+  include:
+    - name: Py3.6
+      python: 3.6
+      dist: bionic
+    - name: Py3.7
+      python: 3.7
+      dist: focal
+    - name: Py3.8
+      python: 3.8
+      dist: focal
+    - name: Py2.7 (legacy)
+      python: 2.7
+      dist: xenial
 addons:
   apt:
     packages:

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
 
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 
         "Natural Language :: English",
 
@@ -68,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     packages=packages,
     package_data=package_data,

--- a/spinn_utilities/default_ordered_dict.py
+++ b/spinn_utilities/default_ordered_dict.py
@@ -13,15 +13,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import OrderedDict
 try:
-    from collections.abc import OrderedDict, Callable
+    from collections.abc import Callable
 except ImportError:
-    from collections import OrderedDict, Callable
+    from collections import Callable
 
 
 class DefaultOrderedDict(OrderedDict):
     # Source: https://stackoverflow.com/questions/6190331
     def __init__(self, default_factory=None, *args, **kwargs):
+        # pylint: disable=keyword-arg-before-vararg
         if (default_factory is not None and
                 not isinstance(default_factory, Callable)):
             raise TypeError('first argument must be callable')

--- a/spinn_utilities/ordered_set.py
+++ b/spinn_utilities/ordered_set.py
@@ -13,152 +13,50 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-
-if sys.version_info >= (3, 6):
+from collections import OrderedDict
+try:
     # pylint: disable=import-error, no-name-in-module
     from collections.abc import MutableSet
-    from collections import OrderedDict
-else:
+except ImportError:
     from collections import MutableSet  # pylint: disable=no-name-in-module
-
-    # Only need Node if we dont have an ordered dict
-    class _Node(object):
-        __slots__ = (
-            "_key", "_prev_node", "_next_node"
-        )
-
-        def __init__(self, key, prev_node, next_node):
-            self._key = key
-            self._prev_node = prev_node
-            self._next_node = next_node
-
-        @property
-        def key(self):
-            return self._key
-
-        @property
-        def prev_node(self):
-            return self._prev_node
-
-        @prev_node.setter
-        def prev_node(self, prev_node):
-            self._prev_node = prev_node
-
-        @property
-        def next_node(self):
-            return self._next_node
-
-        @next_node.setter
-        def next_node(self, next_node):
-            self._next_node = next_node
 
 
 class OrderedSet(MutableSet):
     __slots__ = (
-        "_end", "_map"
+        "_map",
     )
 
-    if sys.version_info >= (3, 6):
-        # Depend on an ordered dict
+    def __init__(self, iterable=None):
+        # pylint: disable=super-init-not-called
+        # Always use OrderedDict as plain dict does not support
+        # __reversed__ and key indexing
+        self._map = OrderedDict()
 
-        def __init__(self, iterable=None):
-            # Always use OrderedDict as plain dict does not support
-            # __reversed__ and key indexing
-            self._map = OrderedDict()
+        # or is overridden in mutable set; calls add on each element
+        if iterable is not None:
+            self |= iterable
 
-            # or is overridden in mutable set; calls add on each element
-            if iterable is not None:
-                self |= iterable
+    def add(self, value):
+        if value not in self._map:
+            self._map[value] = None
 
-        def add(self, value):
-            if value not in self._map:
-                self._map[value] = None
+    def discard(self, value):
+        if value in self._map:
+            self._map.pop(value)
 
-        def discard(self, value):
-            if value in self._map:
-                self._map.pop(value)
+    def __iter__(self):
+        return self._map.__iter__()
 
-        def __iter__(self):
-            return self._map.__iter__()
+    def __reversed__(self):
+        return self._map.__reversed__()
 
-        def __reversed__(self):
-            return self._map.__reversed__()
-
-        def peek(self, last=True):
-            if not self._map:  # i.e., is self._map empty?
-                raise KeyError('set is empty')
-            if last:
-                return next(reversed(self))
-            else:
-                return next(self)
-
-    else:  # if sys.version_info >= (3, 6):
-        # As Python 2.7 does not have an order dict we need a linked list
-
-        def __init__(self, iterable=None):
-            # sentinel node for doubly linked list
-            # prev_node of end points to end of list (for reverse iteration)
-            # next_node of end points to start of list (for forward iteration)
-            self._end = _Node(None, None, None)
-            self._end.prev_node = self._end
-            self._end.next_node = self._end
-
-            # key --> _Node
-            self._map = dict()
-
-            # or is overridden in mutable set; calls add on each element
-            if iterable is not None:
-                self |= iterable
-
-        def add(self, value):
-            if value not in self._map:
-                end_prev = self._end.prev_node
-                new_node = _Node(value, end_prev, self._end)
-                self._map[value] = new_node
-                end_prev.next_node = new_node
-                self._end.prev_node = new_node
-
-        def discard(self, value):
-            if value in self._map:
-                node = self._map.pop(value)
-                prev_node = node.prev_node
-                next_node = node.next_node
-                node.prev_node.next_node = next_node
-                node.next_node.prev_node = prev_node
-
-        def __iter__(self):
-            curr = self._end.next_node
-            while curr is not self._end:
-                yield curr.key
-                curr = curr.next_node
-
-        def __reversed__(self):
-            curr = self._end.prev_node
-            while curr is not self._end:
-                yield curr.key
-                curr = curr.prev_node
-
-        @property
-        def as_list(self):
-            """
-            Shows the sets as a list.
-
-            Main use is to allow debuggers easier access at the set.
-
-            Note: This list is disconnected so will not reflect any changes
-                to the original set.
-
-            :return: Set as a list
-            """
-            return list(self)
-
-        def peek(self, last=True):
-            if not self._map:  # i.e., is self._map empty?
-                raise KeyError('set is empty')
-            return self._end.prev_node.key if last else self._end.next_node.key
-
-    # Functions which work regradless if self._map is ordered
+    def peek(self, last=True):
+        if not self._map:  # i.e., is self._map empty?
+            raise KeyError('set is empty')
+        if last:
+            return next(reversed(self))
+        else:
+            return next(self)
 
     def __len__(self):
         return len(self._map)
@@ -182,7 +80,7 @@ class OrderedSet(MutableSet):
 
     def __eq__(self, other):
         if isinstance(other, OrderedSet):
-            return len(self) == len(other) and list(self) == list(other)
+            return len(self) == len(other) and self._map == other._map
         return set(self) == set(other)
 
     def __ne__(self, other):

--- a/spinn_utilities/progress_bar.py
+++ b/spinn_utilities/progress_bar.py
@@ -209,15 +209,17 @@ class ProgressBar(object):
             if finish_at_end:
                 self.end()
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs):  # @UnusedVariable
+        # pylint: disable=unused-argument
+        c = cls
         if _EnhancedProgressBar._ENABLED:
-            cls = _EnhancedProgressBar
+            c = _EnhancedProgressBar
         if PY3:
             # Disable a pylint error about something that doesn't apply in 2.7
             # pylint: disable=missing-super-argument
-            return super().__new__(cls)
+            return super().__new__(c)
         else:
-            return object.__new__(cls, *args, **kwargs)
+            return object.__new__(c)
 
 
 class _EnhancedProgressBar(ProgressBar):


### PR DESCRIPTION
This adds testing support for Python 3.8

It also more clearly marks (on Travis) our 2.7 support as legacy, and moves the 2.7 testing back to Xenial and the 3.6 testing back to Bionic.