### PR TITLE
Support for Andrew Rowley's complicated derivation case

### DIFF
--- a/unittests/test_require_subclass.py
+++ b/unittests/test_require_subclass.py
@@ -46,6 +46,13 @@ class DerivedIfc(Ifc, allow_derivation=True):
     pass
 
 
+@require_subclass(Base)
+class Ifc2(object, metaclass=AbstractBase):
+    @abstractmethod
+    def bar(self):
+        pass
+
+
 def test_direct():
     class Foo1(FromBase, Ifc):
         def foo(self):
@@ -86,3 +93,22 @@ def test_non_base_double_indirect():
             def foo(self):
                 pass
         assert Foo6().bar == 234
+
+
+def test_double():
+    class Foo7(FromBase, Ifc, Ifc2):
+        pass
+
+
+def test_double_indirect():
+    class Ifc3(Ifc, Ifc2, allow_derivation=True):
+        pass
+
+    class Foo7(FromBase, Ifc3):
+        def foo(self):
+            return 123
+
+        def bar(self):
+            return 234
+
+    assert Foo7() is not None


### PR DESCRIPTION
Sometimes the allow_derivation parameter has to be passed, and sometimes not. This automatically handles the case by detecting the error from not passing it and trying again; that's the least disruptive and easiest to grok. The alternatives (like peeking at the MRO) work, but are much much worse.