### PR TITLE
Split out the list of files to put in documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -350,10 +350,32 @@ epub_exclude_files = ['search.html']
 
 autoclass_content = 'both'
 
-# Do the rst generation
 
-for f in os.listdir("."):
-    if (os.path.isfile(f) and f.endswith(
-            ".rst") and f != "index.rst" and f != "modules.rst"):
-        os.remove(f)
-apidoc.main(['-o', ".", "../../spinn_utilities"])
+def filtered_files(base, unfiltered_files_filename):
+    with open(unfiltered_files_filename) as f:
+        lines = [line.rstrip() for line in f]
+    # Skip comments and empty lines to get list of files we DON'T want to
+    # filter out; this is definitely complicated
+    unfiltered = set(
+        line for line in lines if not line.startswith("#") and line != "")
+    for root, _dirs, files in os.walk(base):
+        for filename in files:
+            if filename.endswith(".py") and not filename.startswith("_"):
+                full = root + "/" + filename
+                if full not in unfiltered:
+                    yield full
+
+
+_output_dir = os.path.abspath(".")
+_unfiltered_files = os.path.abspath("../unfiltered-files.txt")
+_package_base = "spinn_utilities"
+
+# Do the rst generation; remove files which aren't in git first!
+for fl in os.listdir("."):
+    if (os.path.isfile(fl) and fl.endswith(".rst") and
+            fl not in ("index.rst", "modules.rst")):
+        os.remove(fl)
+os.chdir("../..")  # WARNING! RELATIVE FILENAMES CHANGE MEANING HERE!
+apidoc.main([
+    '-o', _output_dir, _package_base,
+    *filtered_files(_package_base, _unfiltered_files)])

--- a/doc/unfiltered-files.txt
+++ b/doc/unfiltered-files.txt
@@ -1,0 +1,40 @@
+# Copyright (c) 2017-2021 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+spinn_utilities/abstract_base.py
+spinn_utilities/abstract_context_manager.py
+spinn_utilities/bytestring_utils.py
+spinn_utilities/classproperty.py
+spinn_utilities/conf_loader.py
+spinn_utilities/default_ordered_dict.py
+spinn_utilities/exceptions.py
+spinn_utilities/executable_finder.py
+spinn_utilities/find_max_success.py
+spinn_utilities/helpful_functions.py
+spinn_utilities/index_is_value.py
+spinn_utilities/log.py
+spinn_utilities/logger_utils.py
+spinn_utilities/ordered_set.py
+spinn_utilities/overrides.py
+spinn_utilities/package_loader.py
+spinn_utilities/ping.py
+spinn_utilities/progress_bar.py
+spinn_utilities/require_subclass.py
+spinn_utilities/safe_eval.py
+spinn_utilities/see.py
+spinn_utilities/socket_address.py
+spinn_utilities/timer.py
+spinn_utilities/make_tools/replacer.py
+spinn_utilities/testing/log_checker.py

--- a/doc/unfiltered-files.txt
+++ b/doc/unfiltered-files.txt
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# Files are listed here if they are NOT imported into their directory/module's
+# __init__.py and reexported with __all__.
+
 spinn_utilities/abstract_base.py
 spinn_utilities/abstract_context_manager.py
 spinn_utilities/bytestring_utils.py


### PR DESCRIPTION
By having the list of files to be explicitly documented as a separate file, I'll be able to use this information from the combined doc build (without having to parse code). Also developed the code pattern for consuming the information.