### PR TITLE
Cleanup config loading and validation

### DIFF
--- a/spinn_utilities/conf_loader.py
+++ b/spinn_utilities/conf_loader.py
@@ -61,7 +61,12 @@ def install_cfg_and_IOError(filename, defaults, config_locations):
                     dst.write("\n")
                     found = True
         if not found:
-            raise ConfigTemplateException("No template file found.")
+            if defaults:
+                raise ConfigTemplateException("No template file found.")
+            else:
+                logger.error(
+                    f"No default cfg files found. "
+                    f"New {home_cfg} will be empty")
 
         dst.write("\n# Additional config options can be found in:\n")
         for source in defaults:
@@ -69,19 +74,18 @@ def install_cfg_and_IOError(filename, defaults, config_locations):
         dst.write("\n# Copy any additional settings you want to change"
                   " here including section headings\n")
 
-    msg = "Unable to find config file in any of the following locations: \n" \
-          "{}\n" \
-          "********************************************************\n" \
-          "{} has been created. \n" \
-          "Please edit this file and change \"None\" after \"machineName\" " \
-          "to the hostname or IP address of your SpiNNaker board, " \
-          "and change \"None\" after \"version\" to the version of " \
-          "SpiNNaker hardware you are running on:\n" \
-          "[Machine]\n" \
-          "machineName = None\n" \
-          "version = None\n" \
-          "***********************************************************\n" \
-          "".format(config_locations, home_cfg)
+    msg = f"Unable to find config file in any of the following locations: \n" \
+          f"{config_locations}\n" \
+          f"********************************************************\n" \
+          f"{home_cfg} has been created. \n" \
+          f"Please edit this file and change \"None\" after \"machineName\" " \
+          f"to the hostname or IP address of your SpiNNaker board, " \
+          f"and change \"None\" after \"version\" to the version of " \
+          f"SpiNNaker hardware you are running on:\n" \
+          f"[Machine]\n" \
+          f"machineName = None\n" \
+          f"version = None\n" \
+          f"***********************************************************\n"
     print(msg)
     return NoConfigFoundException(msg)
 

--- a/spinn_utilities/conf_loader.py
+++ b/spinn_utilities/conf_loader.py
@@ -15,15 +15,14 @@
 
 # pylint: disable=too-many-arguments
 import appdirs
-import collections
 import configparser
 import logging
 import os
 from spinn_utilities import log
 from spinn_utilities.configs import (
-    CamelCaseConfigParser, CaseSensitiveParser, ConfigTemplateException,
+    CamelCaseConfigParser, ConfigTemplateException,
     NoConfigFoundException, UnexpectedConfigException)
-
+from spinn_utilities.helpful_functions import testing
 logger = logging.getLogger(__name__)
 
 
@@ -107,122 +106,7 @@ def logging_parser(config):
         pass
 
 
-def _outdated_config_section(validation_config, defaults, config, skip,
-                             user_sections, section):
-    """ Helper for :py:func:`_outdated_config`.
-    """
-    if section in user_sections:
-        print("Section [{}] should be kept as these need to be set "
-              "by the user".format(section))
-        return
-    elif section not in defaults.sections():
-        if validation_config.has_section("DeadSections") and \
-                section in validation_config.options("DeadSections"):
-            print("Remove the Section [{}]".format(section))
-            print("\tThat section is no longer used.")
-        else:
-            print("Section [{}] does not appear in the defaults so is "
-                  "unchecked".format(section))
-        return
-
-    different = []
-    sames = []
-    all_default = True
-    for option in config.options(section):
-        if option in skip[section]:
-            continue
-        if not defaults.has_option(section, option):
-            print("Unexpected Option [{}] {}".format(section, option))
-            all_default = False
-        elif config.get(section, option) == defaults.get(section, option):
-            sames.append(option)
-        else:
-            different.append(option)
-
-    if not different:
-        if all_default:
-            print("Whole section [{}] same as default".format(section))
-            print("\tIt can be safely removed")
-    elif not sames:
-        print("In Section [{}] all options changed".format(section))
-        print("\tThis section should be kept")
-    elif len(different) < len(sames):
-        print("In Section [{}] only options changed are:".format(section))
-        print("\t{}".format(different))
-        print("\tAll other values can be safely removed")
-    else:
-        print("In Section [{}] options with default values are:".format(
-            section))
-        print("\t{}".format(sames))
-        print("\tThese can be safely removed")
-
-
-def _outdated_config(cfg_file, validation_cfg, default_cfg):
-    """ Prints why a configuration file is outdated and raises an exception.
-
-    Reads a configuration file by itself (Without others)
-
-    Reports errors in this configuration file based on the validation_cfg and\
-    the default_cfg
-
-    Reports any values listed as PreviousValues.\
-    These are specific values in specific options no longer supported.\
-    For example old algorithm names.
-
-    Checks all sections not defined as UserSections (Default Machine)\
-    i.e., ones the user is expected to change
-
-    Any section specifically listed as Dead will be reported
-
-    Any section in the default configuration file is compared, reporting
-    * any unexpected values
-    * the smaller of values non default or values same as default
-
-    Any other section is ignored as assumed being used by an extension
-
-    :param cfg_file: Path to be checked
-    :param validation_cfg: Path containing the validation rules
-    :param default_cfg: List of Paths to default_cfg
-    :return: an exception
-    :rtype: spinn_utilities.configs.UnexpectedConfigException
-    """
-
-    try:
-        print("Your config file {} is outdated.".format(cfg_file))
-        config = CamelCaseConfigParser()
-        config.read(cfg_file)
-
-        seen = collections.defaultdict(set)
-        if validation_cfg.has_section("PreviousValues"):
-            for dead_value in validation_cfg.options("PreviousValues"):
-                key = validation_cfg.get("PreviousValues", dead_value)
-                sect, opt = key.split("|")
-                if config.has_option(sect, opt) and \
-                        dead_value in config.get(sect, opt):
-                    print("Error in Section [{}] the opt {}".format(sect, opt))
-                    print("\t The value below is no longer supported:")
-                    print("\t{}".format(dead_value))
-                    print("\tUnless you specifically need a none "
-                          "default value remove it")
-                    seen[sect].add(opt)
-
-        if validation_cfg.has_section("UserSections"):
-            user_sections = validation_cfg.options("UserSections")
-        else:
-            user_sections = ["Machine"]
-
-        for sect in config.sections():
-            _outdated_config_section(validation_cfg, default_cfg, config,
-                                     seen, user_sections, sect)
-        print("Option names are case and underscore insensitive. "
-              "So may show in your config file with capitals or underscores.")
-    except Exception as e:  # pylint: disable=broad-except
-        print("Unexpected error:", e)
-    return UnexpectedConfigException(
-        "Config file {} is outdated.".format(cfg_file))
-
-
-def _check_config(cfg, cfg_file, validation_cfg, default_cfg):
+def _check_config(cfg_file, default_configs, strict):
     """ Checks the configuration read up to this point to see if it is outdated
 
     Once one difference is found a full reports is generated and an error\
@@ -237,56 +121,50 @@ def _check_config(cfg, cfg_file, validation_cfg, default_cfg):
     These are specific values in specific options no longer supported.\
     For example old algorithm names
 
-    :param cfg: Configuration as read in up to this point
-    :param cfg_file: Path of last file read in
-    :param validation_cfg: Path containing the validation rules
-    :param default_cfg: The list of paths to default configurations
+    :param str cfg_file: Path of last file read in
+    :param CamelCaseConfigParser default_configs:
+        configuration with just the default files in
+    :param bool strict: Flag to say an exception should be raised
     """
-    if validation_cfg is None or default_cfg is None:
+    if not default_configs.sections():  # empty
+        logger.warning("Can not validate cfg files as no default.")
         return
-
-    # Check for sections registered as dead other none default are ignored
-    if validation_cfg.has_section("DeadSections"):
-        for sect in validation_cfg.options("DeadSections"):
-            if cfg.has_section(sect):
-                raise _outdated_config(cfg_file, validation_cfg, default_cfg)
-
-    # check every sect except ones user should change by default machine
-    if validation_cfg.has_section("UserSections"):
-        user_sections = validation_cfg.options("UserSections")
-    else:
-        user_sections = ["Machine"]
-    # check there are no extra options. default options assumed merged in
-    for sect in default_cfg.sections():
-        if sect not in user_sections and \
-                len(default_cfg.options(sect)) != len(cfg.options(sect)):
-            raise _outdated_config(cfg_file, validation_cfg, default_cfg)
-
-    # check for any previous values
-    if validation_cfg.has_section("PreviousValues"):
-        for dead_value in validation_cfg.options("PreviousValues"):
-            key = validation_cfg.get("PreviousValues", dead_value)
-            sect, opt = key.split("|")
-            if dead_value in cfg.get(sect, opt):
-                raise _outdated_config(cfg_file, validation_cfg, default_cfg)
+    configs = CamelCaseConfigParser()
+    configs.read(cfg_file)
+    msg = ""
+    for section in configs.sections():
+        if default_configs.has_section(section):
+            for option in configs.options(section):
+                if not default_configs.has_option(section, option):
+                    msg += f"Unexpected Option: [{section}]{option}\n"
+        else:
+            msg += f"Unexpected Section: [{section}]\n"
+    if msg:
+        msg += f"found in {cfg_file}"
+        if strict:
+            raise UnexpectedConfigException(msg)
+        else:
+            logger.warning(msg)
 
 
-def _read_a_config(config, cfg_file, validation_cfg, default_cfg):
+def _read_a_config(configs, cfg_file, default_configs, strict):
     """ Reads in a configuration file and then directly its machine_spec_file
 
-    :param config: configuration to be updated by the reading of a file
-    :param cfg_file: path to file which should be read in
-    :param validation_cfg: Path containing the validation rules
-    :param default_cfg: The list of paths to default configurations
+    :param CamelCaseConfigParser configs:
+        configuration to be updated by the reading of a file
+    :param str cfg_file: path to file which should be read in
+    :param CamelCaseConfigParser default_configs:
+        configuration with just the default files in
+    :param bool strict: Flag to say checker should raise an exception
     :return: None
     """
-    config.read(cfg_file)
-    _check_config(config, cfg_file, validation_cfg, default_cfg)
-    if config.has_option("Machine", "machine_spec_file"):
-        machine_spec_file = config.get("Machine", "machine_spec_file")
-        config.read(machine_spec_file)
-        _check_config(config, machine_spec_file, validation_cfg, default_cfg)
-        config.remove_option("Machine", "machine_spec_file")
+    _check_config(cfg_file, default_configs, strict)
+    configs.read(cfg_file)
+    if configs.has_option("Machine", "machine_spec_file"):
+        machine_spec_file = configs.get("Machine", "machine_spec_file")
+        _check_config(machine_spec_file, default_configs, strict)
+        configs.read(machine_spec_file)
+        configs.remove_option("Machine", "machine_spec_file")
 
 
 def _config_locations(filename):
@@ -303,14 +181,13 @@ def _config_locations(filename):
     system_config_cfg_file = os.path.join(appdirs.site_config_dir(), dotname)
     user_config_cfg_file = os.path.join(appdirs.user_config_dir(), dotname)
     user_home_cfg_file = os.path.join(os.path.expanduser("~"), dotname)
-    current_directory_cfg_file = os.path.join(os.curdir, filename)
 
     # locations to read as well as default later overrides earlier
     return [system_config_cfg_file, user_config_cfg_file,
-            user_home_cfg_file, current_directory_cfg_file]
+            user_home_cfg_file]
 
 
-def load_config(filename, defaults, config_parsers=None, validation_cfg=None):
+def load_config(filename, defaults, config_parsers=None):
     """ Load the configuration.
 
     :param filename: The base name of the configuration file(s). Should not\
@@ -325,32 +202,25 @@ def load_config(filename, defaults, config_parsers=None, validation_cfg=None):
         already loaded. The standard logging parser is appended to (a copy\
         of) this list.
     :type config_parsers: list(tuple(str, ConfigParser))
-    :param validation_cfg: The list of files to read a validation\
-        configuration from. If omitted, no such validation is performed.
-    :type validation_cfg: list(str)
     :return: the fully-loaded and checked configuration
     """
 
-    cfg = CamelCaseConfigParser()
+    configs = CamelCaseConfigParser()
 
     # locations to read as well as default later overrides earlier
     config_locations = _config_locations(filename)
     if not any(os.path.isfile(f) for f in config_locations):
         raise install_cfg_and_IOError(filename, defaults, config_locations)
 
-    cfg.read(defaults)
+    configs.read(defaults)
 
-    if validation_cfg is not None:
-        v = CaseSensitiveParser()
-        v.read(validation_cfg)
-        d = CamelCaseConfigParser()
-        d.read(defaults)
-    else:
-        v = None
-        d = None
+    default_configs = CamelCaseConfigParser()
+    default_configs.read(defaults)
 
-    for f in config_locations:
-        _read_a_config(cfg, f, v, d)
+    for cfg_file in config_locations:
+        _read_a_config(configs, cfg_file, default_configs, False)
+    cfg_file = os.path.join(os.curdir, filename)
+    _read_a_config(configs, cfg_file, default_configs, True)
 
     parsers = list()
     if config_parsers is not None:
@@ -358,11 +228,11 @@ def load_config(filename, defaults, config_parsers=None, validation_cfg=None):
     parsers.append(("Logging", logging_parser))
 
     for section, parser in parsers:
-        if cfg.has_section(section):
-            parser(cfg)
+        if configs.has_section(section):
+            parser(configs)
 
-    # Log which cfg files we read
-    print(cfg.read_files)
-    logger.info("Read cfg files: %s", ", ".join(cfg.read_files))
+    # Log which configs files we read
+    print(configs.read_files)
+    logger.info("Read configs files: %s", ", ".join(configs.read_files))
 
-    return cfg
+    return configs

--- a/spinn_utilities/conf_loader.py
+++ b/spinn_utilities/conf_loader.py
@@ -22,7 +22,6 @@ from spinn_utilities import log
 from spinn_utilities.configs import (
     CamelCaseConfigParser, ConfigTemplateException,
     NoConfigFoundException, UnexpectedConfigException)
-from spinn_utilities.helpful_functions import testing
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +61,8 @@ def install_cfg_and_IOError(filename, defaults, config_locations):
                     found = True
         if not found:
             if defaults:
-                raise ConfigTemplateException("No template file found.")
+                raise ConfigTemplateException(
+                    f"No template file found for {defaults}")
             else:
                 logger.error(
                     f"No default cfg files found. "

--- a/spinn_utilities/conf_loader.py
+++ b/spinn_utilities/conf_loader.py
@@ -67,8 +67,8 @@ def install_cfg_and_IOError(filename, defaults, config_locations):
         dst.write("\n# Additional config options can be found in:\n")
         for source in defaults:
             dst.write("# {}\n".format(source))
-            dst.write("\n# Copy any additional settings you want to change"
-                      " here including section headings\n")
+        dst.write("\n# Copy any additional settings you want to change"
+                  " here including section headings\n")
 
     msg = "Unable to find config file in any of the following locations: \n" \
           "{}\n" \

--- a/spinn_utilities/conf_loader.py
+++ b/spinn_utilities/conf_loader.py
@@ -214,7 +214,11 @@ def load_config(filename, defaults, config_parsers=None):
     # locations to read as well as default later overrides earlier
     config_locations = _config_locations(filename)
     if not any(os.path.isfile(f) for f in config_locations):
-        raise install_cfg_and_IOError(filename, defaults, config_locations)
+        if defaults:
+            raise install_cfg_and_IOError(
+                filename, defaults, config_locations)
+        else:
+            logger.error("No default cfg files provided")
 
     configs.read(defaults)
 

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -24,7 +24,6 @@ __config = None
 
 __default_config_files = []
 __config_file = None
-__validation_cfg = None
 
 
 def add_default_cfg(default):
@@ -38,14 +37,13 @@ def add_default_cfg(default):
 
 
 def clear_cfg_files():
-    global __config, __config_file, __validation_cfg
+    global __config, __config_file
     __config = None
     __default_config_files.clear()
     __config_file = None
-    __validation_cfg = None
 
 
-def set_cfg_files(configfile, default, validation_cfg=None):
+def set_cfg_files(configfile, default):
     """
     Adds the cfg files to be loaded
 
@@ -54,17 +52,11 @@ def set_cfg_files(configfile, default, validation_cfg=None):
         Should not include any path components.
     :param default: Full path to the extra file to get default configurations
         from.
-    :param validation_cfg:
-        The list of files to read a validation configuration from.
-        If None, no such validation is performed.
-    :type validation_cfg: list(str) or None
-
     :param str default: Absolute path to the cfg file
     """
-    global __config_file, __validation_cfg
+    global __config_file
     __config_file = configfile
     add_default_cfg(default)
-    __validation_cfg = validation_cfg
 
 
 def _pre_load_config():
@@ -87,8 +79,7 @@ def load_config():
     global __config
     if __config_file:
         __config = conf_loader.load_config(
-            filename=__config_file, defaults=__default_config_files,
-            validation_cfg=__validation_cfg)
+            filename=__config_file, defaults=__default_config_files)
     else:
         __config = CamelCaseConfigParser()
         for default in __default_config_files:

--- a/spinn_utilities/helpful_functions.py
+++ b/spinn_utilities/helpful_functions.py
@@ -17,6 +17,7 @@ from functools import reduce
 import logging
 import inspect
 import math
+import os
 import re
 from spinn_utilities.log import FormatAdapter
 
@@ -101,3 +102,18 @@ def gcd(*numbers):
         except TypeError:
             return numbers[0]
     return reduce(math.gcd, numbers)
+
+
+def testing():
+    """
+    Detect if the system is currently testing.
+    Either in pytest or Jenkins
+
+    :return: True if and only if testing detected
+    :rtype: bool
+    """
+    if os.environ.get('CONTINUOUS_INTEGRATION', 'false').lower() == 'true':
+        return True
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return True
+    return False

--- a/spinn_utilities/testing/log_checker.py
+++ b/spinn_utilities/testing/log_checker.py
@@ -83,6 +83,21 @@ def assert_logs_error_contains(log_records, submessage):
     _assert_logs_contains('ERROR', log_records, submessage)
 
 
+def assert_logs_warning_contains(log_records, submessage):
+    """ Checks it the log records contain an WARNING log with this sub-message
+
+    .. note::
+        While this code does not depend on testfixtures,
+        you will need testfixtures to generate the input data
+
+    :param log_records: list of log records returned by testfixtures.LogCapture
+    :param submessage: String which should be part of an WARNING log
+    :rtype: None
+    :raises AssertionError: If the submessage is not present in the log
+    """
+    _assert_logs_contains('WARNING', log_records, submessage)
+
+
 def assert_logs_info_contains(log_records, sub_message):
     """ Checks it the log records contain an INFO log with this sub-message
 

--- a/unittests/test_conf_loader.py
+++ b/unittests/test_conf_loader.py
@@ -111,37 +111,7 @@ def test_new_option(tmpdir, default_config):
         default_config = default_config + "sam=cat\n"
         f.write(default_config)
         with pytest.raises(UnexpectedConfigException):
-            conf_loader.load_config(CFGFILE, [CFGPATH],
-                                    validation_cfg="blank.cfg")
-
-
-def test_new_section_validation(tmpdir, default_config):
-    with tmpdir.as_cwd():
-        f = tmpdir.join(CFGFILE)
-        default_config = default_config + "[Pets]\nsam=cat\n"
-        f.write(default_config)
-        conf_loader.load_config(CFGFILE, [CFGPATH], validation_cfg="blank.cfg")
-
-
-def test_types(tmpdir, default_config):
-    with tmpdir.as_cwd():
-        f = tmpdir.join(CFGFILE)
-        default_config = (
-                default_config +
-                "[machine]\nmachineName=foo\nVersion=5\nsize=4.6\nb1=True\n"
-                "b2=true\nb3=False\nb4=False\nOops=None\n")
-        f.write(default_config)
-        config = conf_loader.load_config(
-            CFGFILE, [CFGPATH], validation_cfg="blank.cfg")
-        assert config.get_int("machine", "version") == 5
-        assert config.get_int("machine", "oops") is None
-        assert config.get_float("machine", "size") == 4.6
-        assert config.get_float("machine", "oops") is None
-        assert config.get_bool("machine", "b1")
-        assert config.get_bool("machine", "b2")
-        assert not config.get_bool("machine", "b3")
-        assert not config.get_bool("machine", "b4")
-        assert config.get_bool("machine", "oops") is None
+            conf_loader.load_config(CFGFILE, [CFGPATH])
 
 
 def test_dead_section(tmpdir, default_config):
@@ -150,30 +120,7 @@ def test_dead_section(tmpdir, default_config):
         default_config = default_config + "[Pets]\nsam=cat\n"
         f.write(default_config)
         with pytest.raises(UnexpectedConfigException):
-            conf_loader.load_config(CFGFILE, [CFGPATH],
-                                    validation_cfg=VALIDATION_PATH)
-
-
-def test_previous_value(tmpdir, default_config):
-    with tmpdir.as_cwd():
-        f = tmpdir.join(CFGFILE)
-        default_config = default_config.replace("bar", "alpha")
-        f.write(default_config)
-        with pytest.raises(UnexpectedConfigException):
-            conf_loader.load_config(CFGFILE, [CFGPATH],
-                                    validation_cfg=VALIDATION_PATH)
-
-
-def test_new_section(tmpdir, default_config):
-    with tmpdir.as_cwd():
-        f = tmpdir.join(CFGFILE)
-        default_config = default_config + "[other]\nsam=cat\n"
-        f.write(default_config)
-        config = conf_loader.load_config(CFGFILE, [CFGPATH])
-        assert config.sections() == ["sect", "other"]
-        assert config.options("sect") == ["foobob"]
-        assert config.get("sect", "foobob") == "bar"
-        assert config.get("other", "sam") == "cat"
+            conf_loader.load_config(CFGFILE, [CFGPATH])
 
 
 def test_use_one_default(tmpdir, not_there):
@@ -264,7 +211,7 @@ def test_str_list(tmpdir):
                 "as_none=None\n"
                 "as_empty=\n"
                 "fluff=more\n")
-        config = conf_loader.load_config(CFGFILE, [CFGPATH])
+        config = conf_loader.load_config(CFGFILE, [])
         assert config.get_str_list("abc", "as_list") == \
                ["bacon", "is", "so", "cool"]
         assert config.get_str_list("abc", "as_none") == []

--- a/unittests/test_conf_loader.py
+++ b/unittests/test_conf_loader.py
@@ -67,32 +67,6 @@ def mach_spec(tmpdir):
     return str(msf)
 
 
-def test_basic_use(tmpdir, default_config):
-    with tmpdir.as_cwd():
-        f = tmpdir.join(CFGFILE)
-        f.write(default_config)
-        config = conf_loader.load_config(CFGFILE, [])
-        assert config is not None
-        assert config.sections() == ["sect"]
-        assert config.options("sect") == ["foobob"]
-        assert config.get("sect", "foobob") == "bar"
-        assert config.get("sect", "fooBob") == "bar"
-        assert config.get("sect", "foo_bob") == "bar"
-
-
-def test_as_default(tmpdir, default_config):
-    with tmpdir.as_cwd():
-        f = tmpdir.join(CFGFILE)
-        f.write(default_config)
-        config = conf_loader.load_config(CFGFILE, [CFGPATH])
-        assert config is not None
-        assert config.sections() == ["sect"]
-        assert config.options("sect") == ["foobob"]
-        assert config.get("sect", "foobob") == "bar"
-        assert config.get("sect", "fooBob") == "bar"
-        assert config.get("sect", "foo_bob") == "bar"
-
-
 def test_different_value(tmpdir, default_config):
     with tmpdir.as_cwd():
         f = tmpdir.join(CFGFILE)

--- a/unittests/test_conf_loader.py
+++ b/unittests/test_conf_loader.py
@@ -32,9 +32,9 @@ ONEPATH = os.path.join(os.path.dirname(unittests.__file__), ONEFILE)
 TWOFILE = "config_two.cfg"
 TWOPATH = os.path.join(os.path.dirname(unittests.__file__), TWOFILE)
 THREEFILE = "config_three.cfg"
-THREEPATH = os.path.join(os.path.dirname(unittests.__file__), TWOFILE)
+THREEPATH = os.path.join(os.path.dirname(unittests.__file__), THREEFILE)
 FOURFILE = "config_four.cfg"
-FOURPATH = os.path.join(os.path.dirname(unittests.__file__), TWOFILE)
+FOURPATH = os.path.join(os.path.dirname(unittests.__file__), FOURFILE)
 VALIDATION_PATH = os.path.join(os.path.dirname(unittests.__file__),
                                "validation_config.cfg")
 
@@ -147,7 +147,7 @@ def test_no_templates(tmpdir, default_config, not_there):  # @UnusedVariable
 def test_one_templates(tmpdir, default_config, not_there):  # @UnusedVariable
     name, place = not_there
     with tmpdir.as_cwd():
-        with pytest.raises(ConfigTemplateException):
+        with pytest.raises(NoConfigFoundException):
             conf_loader.load_config(name, [FOURPATH, ONEPATH, THREEPATH])
 
 

--- a/unittests/test_conf_loader.py
+++ b/unittests/test_conf_loader.py
@@ -43,7 +43,7 @@ VALIDATION_PATH = os.path.join(os.path.dirname(unittests.__file__),
 def not_there():
     name = "test_config_for_spinnutils_unittests.{}.txt".format(
         random.randint(1, 1000000))
-    place = os.path.join(os.path.expanduser("~"), ".{}".format(name))
+    place = os.path.join(os.path.expanduser("~"), f".{name}")
     if os.path.exists(place):
         # Check existing is a config from previsous test run
         config = configparser.ConfigParser()
@@ -68,15 +68,14 @@ def mach_spec(tmpdir):
 
 
 def test_different_value(tmpdir, default_config):
-    with tmpdir.as_cwd():
-        f = tmpdir.join(CFGFILE)
-        default_config = default_config.replace("bar", "cat")
-        f.write(default_config)
-        config = conf_loader.load_config(CFGFILE, [CFGPATH])
-        assert config is not None
-        assert config.sections() == ["sect"]
-        assert config.options("sect") == ["foobob"]
-        assert config.get("sect", "foobob") == "cat"
+    name, place = not_there
+    default_config = default_config.replace("bar", "cat")
+    place.write(default_config)
+    config = conf_loader.load_config(name, [CFGPATH])
+    assert config is not None
+    assert config.sections() == ["sect"]
+    assert config.options("sect") == ["foobob"]
+    assert config.get("sect", "foobob") == "cat"
 
 
 def test_new_option(tmpdir, default_config):

--- a/unittests/test_helpful_functions.py
+++ b/unittests/test_helpful_functions.py
@@ -15,7 +15,7 @@
 
 import unittests
 from spinn_utilities.helpful_functions import (
-    get_valid_components, is_singleton, gcd, lcm)
+    get_valid_components, is_singleton, gcd, lcm, testing)
 
 
 def test_is_singleton():
@@ -66,6 +66,9 @@ def test_lcm():
     assert lcm(b) == 3000
     c = [34]
     assert lcm(c) == 34
+
+def test_testing():
+    assert (testing())
 
 
 # Support class for test_get_valid_components

--- a/unittests/test_helpful_functions.py
+++ b/unittests/test_helpful_functions.py
@@ -67,6 +67,7 @@ def test_lcm():
     c = [34]
     assert lcm(c) == 34
 
+
 def test_testing():
     assert (testing())
 


### PR DESCRIPTION
This makes a few changes to how config files are loaded that should not be visible to users.

Having a cfg in the script direct no longer stops the creating of a home cfg if there is not one
    - unit tests adapted to always create a home cfg (except those testing no home cfg)

Validation has been simplified.
    - all sections/ options in the home/ script must be on one of the defaults
    - extra in the home(user) cfg causes a warning
          Avoids the need to change when switching branch
   - extra in the script cfg causes an error.
          Identities tests/ examples with out of date cfg
   - ability to give more detailed error/warning message removed as unused and complex

helpful_function testing() added to return true if in testing mode
    nded up not using but could be useful later
 
