### PR TITLE
Unittest setup

### DIFF
--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -73,18 +73,16 @@ def _pre_load_config():
     Loads configs due to early access to a config value
 
     """
-    # Only expected to happen in unittests but just in case
+    # If you getthis error during a unittest then unittest_step was not called
     if not __unittest_mode:
-        logger.warning(
-            "Accessing config before setup is not recommended as setup could"
-            " change some config values. ")
+        raise Exception(
+            "Accessing config values before setup is not supported")
     load_config()
 
 
 def load_config():
     """
     Reads in all the config files, resetting all values.
-
     """
     global __config
     if not __default_config_files:

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -49,7 +49,7 @@ def clear_cfg_files(unittest_mode):
     __config = None
     __default_config_files.clear()
     __config_file = None
-    __unittest_mode = None
+    __unittest_mode = unittest_mode
 
 
 def set_cfg_files(configfile, default):

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -194,7 +194,7 @@ def set_config(section, option, value):
             # set_config but this discourages the use outside of unittests
             raise Exception(
                 "set_config should only be called by unittests "
-                "which should have called reset_configs")
+                "which should have called unittest_setup")
     __config.set(section, option, value)
     # Intentionally no try here to force tests that set to
     # load_default_configs before AND after

--- a/spinn_utilities/config_setup.py
+++ b/spinn_utilities/config_setup.py
@@ -20,15 +20,16 @@ from spinn_utilities.config_holder import (
 BASE_CONFIG_FILE = "spinn_utilities.cfg"
 
 
-def reset_configs():
+def unittest_setup(unittest_mode):
     """
     Resets the configs so only the local default config is included.
 
     .. note::
         This file should only be called from SpiNNUtils/unittests
 
+    :param unittest_mode: Flag to indicate in unittests
     """
-    clear_cfg_files()
+    clear_cfg_files(True)
     add_spinn_utilities_cfg()
 
 


### PR DESCRIPTION
The steps that tests needed to do before (and after) accessing configs or global variables was getting confusing.

This set of PRs adds a single unittest_Setup method which

1. Clears out any previously read in configs
2. Identifies the config file to read in if needed
3. Clears out any simulator previously set
4. Puts the global_variables into unittest mode so default values can be provided

Allows the get_config and global_variables methods to raise an exception in neither unittest_setup nor sim.setup() was called.

The error messages are targeted at none unit test usage,

While many test do not actually need unittest_step the choice was to call it from all except.
1. One that call sim.setup
2. import all to make sure the import works without