### PR TITLE
safety formatter

### DIFF
--- a/spinn_utilities/log.py
+++ b/spinn_utilities/log.py
@@ -128,7 +128,13 @@ class _BraceMessage(object):
         self.kwargs = kwargs
 
     def __str__(self):
-        return str(self.fmt).format(*self.args, **self.kwargs)
+        try:
+            return str(self.fmt).format(*self.args, **self.kwargs)
+        except KeyError:
+            try:
+                return "keyError" + str(self.fmt)
+            except KeyError:
+                return "Double keyError"
 
 
 class LogLevelTooHighException(Exception):


### PR DESCRIPTION
This was discovered during the no executor work and therefor the same name but can easily be merged in before.

Just a little safety to avoid a crash de to a weirdness in logging.