### PR TITLE
replace id param with the_id

### DIFF
--- a/spinn_utilities/ranged/abstract_list.py
+++ b/spinn_utilities/ranged/abstract_list.py
@@ -639,7 +639,8 @@ class DualList(AbstractList, metaclass=AbstractBase):
     @overrides(AbstractList.get_value_by_id)
     def get_value_by_id(self, the_id):
         return self._operation(
-            self._left.get_value_by_id(the_id), self._right.get_value_by_id(the_id))
+            self._left.get_value_by_id(the_id),
+            self._right.get_value_by_id(the_id))
 
     @overrides(AbstractList.get_single_value_by_slice)
     def get_single_value_by_slice(self, slice_start, slice_stop):

--- a/spinn_utilities/ranged/abstract_list.py
+++ b/spinn_utilities/ranged/abstract_list.py
@@ -137,11 +137,11 @@ class AbstractList(AbstractSized, metaclass=AbstractBase):
         return only_range[2]
 
     @abstractmethod
-    def get_value_by_id(self, id):  # @ReservedAssignment
+    def get_value_by_id(self, the_id):
         """ Returns the value for one item in the list
 
-        :param id: One of the IDs of an element in the list
-        :type id: int
+        :param the_id: One of the IDs of an element in the list
+        :type the_id: int
         :return: The value of that element
         """
 
@@ -207,16 +207,16 @@ class AbstractList(AbstractSized, metaclass=AbstractBase):
         else:
             raise TypeError("Invalid argument type.")
 
-    def iter_by_id(self, id):  # @ReservedAssignment
+    def iter_by_id(self, the_id):
         """ Fast but *not* update-safe iterator by one ID.
 
         While ``next`` can only be called once, this is an iterator so it can
         be mixed in with other iterators.
 
-        :param id: ID
+        :param the_id: ID
         :return: yields the elements
         """
-        yield self.get_value_by_id(id)
+        yield self.get_value_by_id(the_id)
 
     def iter_by_ids(self, ids):
         """ Fast but *not* update-safe iterator by collection of IDs.
@@ -367,7 +367,7 @@ class AbstractList(AbstractSized, metaclass=AbstractBase):
         :return: yields each range one by one
         """
 
-    def iter_ranges_by_id(self, id):  # @ReservedAssignment
+    def iter_ranges_by_id(self, the_id):
         """ Iterator of the range for this ID
 
         .. note::
@@ -379,10 +379,10 @@ class AbstractList(AbstractSized, metaclass=AbstractBase):
         :return: yields the one range
         """
 
-        self._check_id_in_range(id)
+        self._check_id_in_range(the_id)
         for (_, stop, value) in self.iter_ranges():
-            if id < stop:
-                yield (id, id + 1, value)
+            if the_id < stop:
+                yield (the_id, the_id + 1, value)
                 break
 
     @abstractmethod
@@ -580,8 +580,8 @@ class SingleList(AbstractList, metaclass=AbstractBase):
         return self._a_list.range_based()
 
     @overrides(AbstractList.get_value_by_id)
-    def get_value_by_id(self, id):  # @ReservedAssignment
-        return self._operation(self._a_list.get_value_by_id(id))
+    def get_value_by_id(self, the_id):
+        return self._operation(self._a_list.get_value_by_id(the_id))
 
     @overrides(AbstractList.get_single_value_by_slice)
     def get_single_value_by_slice(self, slice_start, slice_stop):
@@ -637,9 +637,9 @@ class DualList(AbstractList, metaclass=AbstractBase):
         return self._left.range_based() and self._right.range_based()
 
     @overrides(AbstractList.get_value_by_id)
-    def get_value_by_id(self, id):  # @ReservedAssignment
+    def get_value_by_id(self, the_id):
         return self._operation(
-            self._left.get_value_by_id(id), self._right.get_value_by_id(id))
+            self._left.get_value_by_id(the_id), self._right.get_value_by_id(the_id))
 
     @overrides(AbstractList.get_single_value_by_slice)
     def get_single_value_by_slice(self, slice_start, slice_stop):

--- a/spinn_utilities/ranged/abstract_sized.py
+++ b/spinn_utilities/ranged/abstract_sized.py
@@ -42,22 +42,22 @@ class AbstractSized(object):
         return self._size
 
     @staticmethod
-    def _is_id_type(id):  # @ReservedAssignment
+    def _is_id_type(the_id):
         """ Check if the given ID has a type acceptable for IDs. """
-        return isinstance(id, int)
+        return isinstance(the_id, int)
 
-    def _check_id_in_range(self, id):  # @ReservedAssignment
-        if id < 0:
-            if self._is_id_type(id):
+    def _check_id_in_range(self, the_id):
+        if the_id < 0:
+            if self._is_id_type(the_id):
                 raise IndexError(
-                    "The index {} is out of range.".format(id))
+                    "The index {} is out of range.".format(the_id))
             # pragma: no cover
-            raise TypeError("Invalid argument type {}.".format(type(id)))
-        if id >= self._size:
-            if self._is_id_type(id):
+            raise TypeError("Invalid argument type {}.".format(type(the_id)))
+        if the_id >= self._size:
+            if self._is_id_type(the_id):
                 raise IndexError(
-                    "The index {0} is out of range.".format(id))
-            raise TypeError("Invalid argument type {}.".format(type(id)))
+                    "The index {0} is out of range.".format(the_id))
+            raise TypeError("Invalid argument type {}.".format(type(the_id)))
 
     def _check_slice_in_range(self, slice_start, slice_stop):
         if slice_start is None:

--- a/spinn_utilities/ranged/ids_view.py
+++ b/spinn_utilities/ranged/ids_view.py
@@ -44,11 +44,11 @@ class _IdsView(AbstractView):
     def set_value(self, key, value, use_list_as_value=False):
         ranged_list = self._range_dict.get_list(key)
         for _id in self._ids:
-            ranged_list.set_value_by_id(id=_id, value=value)
+            ranged_list.set_value_by_id(the_id=_id, value=value)
 
     def set_value_by_ids(self, key, ids, value):
         for _id in ids:
-            self._range_dict[key].set_value_by_id(id=_id, value=value)
+            self._range_dict[key].set_value_by_id(the_id=_id, value=value)
 
     @overrides(AbstractDict.iter_all_values)
     def iter_all_values(self, key, update_save=False):

--- a/spinn_utilities/ranged/range_dictionary.py
+++ b/spinn_utilities/ranged/range_dictionary.py
@@ -80,7 +80,7 @@ class RangeDictionary(AbstractSized, AbstractDict):
         # Key is an int - return single view
         if isinstance(key, int):
             self._check_id_in_range(key)
-            return _SingleView(range_dict=self, id=key)
+            return _SingleView(range_dict=self, the_id=key)
 
         # Key is a slice - return a sliced view
         if isinstance(key, slice):
@@ -93,7 +93,7 @@ class RangeDictionary(AbstractSized, AbstractDict):
 
             # Slice is really just one item - return a single view
             if slice_start == slice_stop - 1:
-                return _SingleView(range_dict=self, id=slice_start)
+                return _SingleView(range_dict=self, the_id=slice_start)
 
             # Slice is continuous - return a slice view
             elif key.step is None or key.step == 1:
@@ -110,7 +110,7 @@ class RangeDictionary(AbstractSized, AbstractDict):
 
         # Key is really just a single int - return single view
         if len(key) == 1:
-            return _SingleView(range_dict=self, id=key[0])
+            return _SingleView(range_dict=self, the_id=key[0])
 
         # Key is really just a slice (i.e. one of each key in order without
         # holes) - return a slice view
@@ -150,20 +150,20 @@ class RangeDictionary(AbstractSized, AbstractDict):
             results[a_key] = self._value_lists[a_key].get_single_value_all()
         return results
 
-    def get_values_by_id(self, key, id):  # @ReservedAssignment
+    def get_values_by_id(self, key, the_id):
         """ Same as :py:meth:`get_value` but limited to a single ID.
 
         :param key: as :py:meth:`get_value`
-        :param id: single int ID
+        :param the_id: single int ID
         :return: See :py:meth:`get_value`
         """
         if isinstance(key, str):
-            return self._value_lists[key].get_value_by_id(id)
+            return self._value_lists[key].get_value_by_id(the_id)
         if key is None:
             key = self.keys()
         results = dict()
         for a_key in key:
-            results[a_key] = self._value_lists[a_key].get_value_by_id(id)
+            results[a_key] = self._value_lists[a_key].get_value_by_id(the_id)
         return results
 
     def get_list(self, key):
@@ -182,8 +182,8 @@ class RangeDictionary(AbstractSized, AbstractDict):
         """ Same as :py:meth:`iter_all_values` \
             but limited to a collection of IDs and update-safe.
         """
-        for id_value in ids:  # @ReservedAssignment
-            yield self.get_values_by_id(key=key, id=id_value)
+        for id_value in ids:
+            yield self.get_values_by_id(key=key, the_id=id_value)
 
     @overrides(AbstractDict.iter_all_values, extend_defaults=True)
     def iter_all_values(self, key=None, update_save=False):
@@ -316,20 +316,21 @@ class RangeDictionary(AbstractSized, AbstractDict):
             ranges[a_key] = self._value_lists[a_key].iter_ranges()
         return self._merge_ranges(ranges)
 
-    def iter_ranges_by_id(self, key=None, id=None):  # @ReservedAssignment
+    def iter_ranges_by_id(self, key=None, the_id=None):
         """ Same as :py:meth:`iter_ranges` but limited to one ID.
 
         :param key: see :py:meth:`iter_ranges` parameter key
-        :param id: single ID which is the actual ID and not an index into IDs
-        :type id: int
+        :param the_id: single ID which is the actual ID and not an index into IDs
+        :type the_id: int
         """
         if isinstance(key, str):
-            return self._value_lists[key].iter_ranges_by_id(id=id)
+            return self._value_lists[key].iter_ranges_by_id(the_id=the_id)
         if key is None:
             key = self.keys()
         ranges = dict()
         for a_key in key:
-            ranges[a_key] = self._value_lists[a_key].iter_ranges_by_id(id=id)
+            ranges[a_key] = self._value_lists[a_key].iter_ranges_by_id(
+                the_id=the_id)
         return self._merge_ranges(ranges)
 
     def iter_ranges_by_slice(self, key, slice_start, slice_stop):

--- a/spinn_utilities/ranged/range_dictionary.py
+++ b/spinn_utilities/ranged/range_dictionary.py
@@ -320,7 +320,8 @@ class RangeDictionary(AbstractSized, AbstractDict):
         """ Same as :py:meth:`iter_ranges` but limited to one ID.
 
         :param key: see :py:meth:`iter_ranges` parameter key
-        :param the_id: single ID which is the actual ID and not an index into IDs
+        :param the_id:
+            single ID which is the actual ID and not an index into IDs
         :type the_id: int
         """
         if isinstance(key, str):

--- a/spinn_utilities/ranged/ranged_list.py
+++ b/spinn_utilities/ranged/ranged_list.py
@@ -337,7 +337,8 @@ class RangedList(AbstractList):
 
                 # Need a new range after the ID
                 if the_id + 1 < stop:
-                    self._ranges.insert(index + 1, (the_id + 1, stop, old_value))
+                    self._ranges.insert(
+                        index + 1, (the_id + 1, stop, old_value))
 
                 # Need a new range before the ID
                 if the_id > start:

--- a/spinn_utilities/ranged/ranged_list.py
+++ b/spinn_utilities/ranged/ranged_list.py
@@ -80,20 +80,20 @@ class RangedList(AbstractList):
         return self._ranged_based
 
     @overrides(AbstractList.get_value_by_id)
-    def get_value_by_id(self, id):  # @ReservedAssignment
-        self._check_id_in_range(id)
+    def get_value_by_id(self, the_id):
+        self._check_id_in_range(the_id)
 
         # If range based, find the range containing the value and return
         if self._ranged_based:
             for (_, stop, value) in self._ranges:
-                if id < stop:
+                if the_id < stop:
                     return value  # pragma: no cover
 
             # Must never get here because the ID is in range
             raise ValueError  # pragma: no cover
 
         # Non-range-based so just return the value
-        return self._ranges[id]
+        return self._ranges[the_id]
 
     @overrides(AbstractList.get_single_value_by_slice)
     def get_single_value_by_slice(self, slice_start, slice_stop):
@@ -306,7 +306,7 @@ class RangedList(AbstractList):
             self._ranges.append((0, self._size, value))
             self._ranged_based = True
 
-    def set_value_by_id(self, id, value):  # @ReservedAssignment
+    def set_value_by_id(self, the_id, value):
         """ Sets the value for a single ID to the new value.
 
         .. note::
@@ -314,34 +314,34 @@ class RangedList(AbstractList):
             Use ``set`` or ``__set__`` for slices, tuples, lists and negative
             indexes.
 
-        :param int id: Single ID
+        :param int the_id: Single ID
         :param object value: The value to save
         """
-        self._check_id_in_range(id)
+        self._check_id_in_range(the_id)
 
         # If non-range-based, set the value directly
         if not self._ranged_based:
-            self._ranges[id] = value
+            self._ranges[the_id] = value
             return
 
         # Find the range in which to set the value
         for index, (start, stop, old_value) in enumerate(self._ranges):
-            if id < stop:
+            if the_id < stop:
 
                 # If already set as needed, do nothing
                 if numpy.array_equal(value, old_value):
                     return
 
                 # Split the ID out of the range
-                self._ranges[index] = (id, id + 1, value)
+                self._ranges[index] = (the_id, the_id + 1, value)
 
                 # Need a new range after the ID
-                if id + 1 < stop:
-                    self._ranges.insert(index + 1, (id + 1, stop, old_value))
+                if the_id + 1 < stop:
+                    self._ranges.insert(index + 1, (the_id + 1, stop, old_value))
 
                 # Need a new range before the ID
-                if id > start:
-                    self._ranges.insert(index, (start, id, old_value))
+                if the_id > start:
+                    self._ranges.insert(index, (start, the_id, old_value))
 
                 # If not at the last range, update the start and stop value of
                 # the next range

--- a/spinn_utilities/ranged/single_view.py
+++ b/spinn_utilities/ranged/single_view.py
@@ -22,11 +22,11 @@ class _SingleView(AbstractView):
     __slots__ = [
         "_id"]
 
-    def __init__(self, range_dict, id):  # @ReservedAssignment
+    def __init__(self, range_dict, the_id):
         """ Use :py:meth:`RangeDictionary.view_factory` to create views
         """
         super().__init__(range_dict)
-        self._id = id
+        self._id = the_id
 
     def __str__(self):
         return "View with ID: {}".format(self._id)
@@ -37,20 +37,21 @@ class _SingleView(AbstractView):
 
     @overrides(AbstractDict.get_value)
     def get_value(self, key):
-        return self._range_dict.get_list(key).get_value_by_id(id=self._id)
+        return self._range_dict.get_list(key).get_value_by_id(the_id=self._id)
 
     @overrides(AbstractDict.iter_all_values)
     def iter_all_values(self, key, update_save=False):
         if isinstance(key, str):
-            yield self._range_dict.get_list(key).get_value_by_id(id=self._id)
+            yield self._range_dict.get_list(key).get_value_by_id(
+                the_id=self._id)
         else:
-            yield self._range_dict.get_values_by_id(key=key, id=self._id)
+            yield self._range_dict.get_values_by_id(key=key, the_id=self._id)
 
     @overrides(AbstractDict.set_value)
     def set_value(self, key, value, use_list_as_value=False):
         return self._range_dict.get_list(key).set_value_by_id(
-            value=value, id=self._id)
+            value=value, the_id=self._id)
 
     @overrides(AbstractDict.iter_ranges)
     def iter_ranges(self, key=None):
-        return self._range_dict.iter_ranges_by_id(key=key, id=self._id)
+        return self._range_dict.iter_ranges_by_id(key=key, the_id=self._id)

--- a/spinn_utilities/ranged/slice_view.py
+++ b/spinn_utilities/ranged/slice_view.py
@@ -43,8 +43,8 @@ class _SliceView(AbstractView):
 
     def update_save_iter_all_values(self, key):
         ranged_list = self._range_dict.get_list(key)
-        for id in self.ids():  # @ReservedAssignment
-            yield ranged_list.get_value_by_id(id=id)
+        for the_id in self.ids():
+            yield ranged_list.get_value_by_id(the_id=the_id)
 
     @overrides(AbstractDict.iter_all_values, extend_defaults=True)
     def iter_all_values(self, key=None, update_save=False):


### PR DESCRIPTION
This removed the pylint warning W0622: Redefining built-in 'id' (redefined-builtin)

I had started to replace all "id" with index but that would be a much bigger change so backed out.