### PR TITLE
Log level

### DIFF
--- a/spinn_utilities/conf_loader.py
+++ b/spinn_utilities/conf_loader.py
@@ -100,8 +100,8 @@ def logging_parser(config):
     """
     try:
         if config.getboolean("Logging", "instantiate"):
-            logging.basicConfig(level=0)
-
+            level = config.get("Logging", "default").upper()
+            logging.basicConfig(level=level)
         for handler in logging.root.handlers:
             handler.addFilter(log.ConfiguredFilter(config))
             handler.setFormatter(log.ConfiguredFormatter(config))

--- a/spinn_utilities/log.py
+++ b/spinn_utilities/log.py
@@ -212,16 +212,15 @@ class FormatAdapter(logging.LoggerAdapter):
         """
         if level >= FormatAdapter.__kill_level:
             raise LogLevelTooHighException(_BraceMessage(msg, args, kwargs))
-        if level >= FormatAdapter.__repeat_at_end:
+        if self.isEnabledFor(level) or level >= FormatAdapter.__repeat_at_end:
             message = _BraceMessage(msg, args, kwargs)
-            FormatAdapter.__repeat_messages.append((message))
-            if self.__report_file:
-                with open(self.__report_file, "a", encoding="utf-8")\
-                        as report_file:
-                    report_file.write(message.fmt)
-                    report_file.write("\n")
-        if self.isEnabledFor(level):
-            message = _BraceMessage(msg, args, kwargs)
+            if level >= FormatAdapter.__repeat_at_end:
+                FormatAdapter.__repeat_messages.append((message))
+                if self.__report_file:
+                    with open(self.__report_file, "a", encoding="utf-8")\
+                            as report_file:
+                        report_file.write(message.fmt)
+                        report_file.write("\n")
             msg, log_kwargs = self.process(msg, kwargs)
             if "exc_info" in kwargs:
                 log_kwargs["exc_info"] = kwargs["exc_info"]

--- a/spinn_utilities/log.py
+++ b/spinn_utilities/log.py
@@ -212,15 +212,15 @@ class FormatAdapter(logging.LoggerAdapter):
         """
         if level >= FormatAdapter.__kill_level:
             raise LogLevelTooHighException(_BraceMessage(msg, args, kwargs))
-        message = _BraceMessage(msg, args, kwargs)
-        if level >= FormatAdapter.__repeat_at_end:
-            FormatAdapter.__repeat_messages.append((message))
-            if self.__report_file:
-                with open(self.__report_file, "a", encoding="utf-8")\
-                        as report_file:
-                    report_file.write(message.fmt)
-                    report_file.write("\n")
         if self.isEnabledFor(level):
+            message = _BraceMessage(msg, args, kwargs)
+            if level >= FormatAdapter.__repeat_at_end:
+                FormatAdapter.__repeat_messages.append((message))
+                if self.__report_file:
+                    with open(self.__report_file, "a", encoding="utf-8")\
+                            as report_file:
+                        report_file.write(message.fmt)
+                        report_file.write("\n")
             msg, log_kwargs = self.process(msg, kwargs)
             if "exc_info" in kwargs:
                 log_kwargs["exc_info"] = kwargs["exc_info"]

--- a/spinn_utilities/log.py
+++ b/spinn_utilities/log.py
@@ -212,15 +212,16 @@ class FormatAdapter(logging.LoggerAdapter):
         """
         if level >= FormatAdapter.__kill_level:
             raise LogLevelTooHighException(_BraceMessage(msg, args, kwargs))
+        if level >= FormatAdapter.__repeat_at_end:
+            message = _BraceMessage(msg, args, kwargs)
+            FormatAdapter.__repeat_messages.append((message))
+            if self.__report_file:
+                with open(self.__report_file, "a", encoding="utf-8")\
+                        as report_file:
+                    report_file.write(message.fmt)
+                    report_file.write("\n")
         if self.isEnabledFor(level):
             message = _BraceMessage(msg, args, kwargs)
-            if level >= FormatAdapter.__repeat_at_end:
-                FormatAdapter.__repeat_messages.append((message))
-                if self.__report_file:
-                    with open(self.__report_file, "a", encoding="utf-8")\
-                            as report_file:
-                        report_file.write(message.fmt)
-                        report_file.write("\n")
             msg, log_kwargs = self.process(msg, kwargs)
             if "exc_info" in kwargs:
                 log_kwargs["exc_info"] = kwargs["exc_info"]


### PR DESCRIPTION
To make sure the FormatAdapter.isEnabledFor(level) works

We set logging.basicConfig to the cfg default level not 0

Creating _BraceMessage only done if log is of interest.

level >= FormatAdapter.__repeat_at_end could be called twice but only if repeat_level < enabled level.

Doing it this way means that if we later log to db we can also log to db if gate passes.




