### PR TITLE
No space check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -243,13 +243,6 @@ max-line-length=100
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no

--- a/unittests/ranged/single_over_none_list_test.py
+++ b/unittests/ranged/single_over_none_list_test.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import numpy
 from spinn_utilities.ranged import RangedList, SingleList
 
 
@@ -34,7 +35,6 @@ def test_muliple():
 
 
 def create_lambda():
-    import numpy
     machine_time_step = 1000
     return lambda x: numpy.exp(float(-machine_time_step) / (1000.0 * x))
 
@@ -42,9 +42,10 @@ def create_lambda():
 def test_complex():
     a_list = RangedList(5, [2, 1, 2, 3, 4], "many")
     single = SingleList(a_list=a_list, operation=create_lambda())
-    assert single == [0.60653065971263342, 0.36787944117144233,
-                      0.60653065971263342, 0.716531310573789272,
-                      0.77880078307140488]
+    assert numpy.allclose(
+        single,
+        [0.60653065971263342, 0.36787944117144233, 0.60653065971263342,
+         0.716531310573789272, 0.77880078307140488])
 
 
 def test_get_value():


### PR DESCRIPTION
Same as https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/946

Plus a minor change to a test as
numpy.exp(float(-machine_time_step) / (1000.0 * 1)) gives 0.3678794411714424 in the latest version but 0.36787944117144233 in older ones