### PR TITLE
adds is_reset_last method

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -270,10 +270,13 @@ class UtilsDataView(object):
                 ResetStatus.SOFT_RESET, ResetStatus.HARD_RESET]:
             if cls.__data._run_status == RunStatus.NOT_RUNNING:
                 return True
-            if cls.__data._run_status in [
-                    RunStatus.IN_RUN, RunStatus.STOP_REQUESTED,
-                    RunStatus.STOPPING, RunStatus.SHUTDOWN]:
+            if cls.__data._run_status == RunStatus.IN_RUN:
                 return False
+        if cls.__data._run_status in [
+            RunStatus.STOP_REQUESTED, RunStatus.STOPPING, RunStatus.SHUTDOWN]:
+            raise SimulatorShutdownException(
+                "This call is not supported after sim.stop/end or "
+                "sim.end has been called")
         raise NotImplementedError(
             f"This call was not expected with reset status "
             f"{cls.__data._reset_status} and run status "

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -205,7 +205,7 @@ class UtilsDataView(object):
         Critically during the first run after reset this continues to return
         True!
 
-        Returns False after a reset that was considered soft.
+        Returns False after a reset that was considered hard.
 
         :rtype: bool
         """
@@ -251,6 +251,18 @@ class UtilsDataView(object):
 
     @classmethod
     def is_reset_last(cls):
+        """
+        Reports if sim.reset called since the last sim.run
+
+        Unlike is_soft_reset and is_hard_reset this method return False during
+        any sim.run
+
+        It also returns False after a sim.stop or sim.end call starts
+
+        :rytpe: bool
+        :raises NotImplementedError:
+            If this is called from an unexpected state
+        """
         if cls.__data._reset_status in [
                 ResetStatus.SETUP, ResetStatus.HAS_RUN]:
             return False

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -250,6 +250,24 @@ class UtilsDataView(object):
             f"{cls.__data._reset_status}")
 
     @classmethod
+    def is_reset_last(cls):
+        if cls.__data._reset_status in [
+                ResetStatus.SETUP, ResetStatus.HAS_RUN]:
+            return False
+        if cls.__data._reset_status in [
+                ResetStatus.SOFT_RESET, ResetStatus.HARD_RESET]:
+            if cls.__data._run_status == RunStatus.NOT_RUNNING:
+                return True
+            if cls.__data._run_status in [
+                    RunStatus.IN_RUN, RunStatus.STOP_REQUESTED,
+                    RunStatus.STOPPING, RunStatus.SHUTDOWN]:
+                return False
+        raise NotImplementedError(
+            f"This call was not expected with reset status "
+            f"{cls.__data._reset_status} and run status "
+            f"{cls.__data._run_status}")
+
+    @classmethod
     def is_no_stop_requested(cls):
         """
         Checks that a stop request has not been sent

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -273,7 +273,8 @@ class UtilsDataView(object):
             if cls.__data._run_status == RunStatus.IN_RUN:
                 return False
         if cls.__data._run_status in [
-            RunStatus.STOP_REQUESTED, RunStatus.STOPPING, RunStatus.SHUTDOWN]:
+                RunStatus.STOP_REQUESTED, RunStatus.STOPPING,
+                RunStatus.SHUTDOWN]:
             raise SimulatorShutdownException(
                 "This call is not supported after sim.stop/end or "
                 "sim.end has been called")

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -58,6 +58,8 @@ class TestUtilsData(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_ran_last()
         with self.assertRaises(NotImplementedError):
+            UtilsDataView.is_reset_last()
+        with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
         self.assertFalse(UtilsDataView.is_setup())
@@ -80,6 +82,8 @@ class TestUtilsData(unittest.TestCase):
             UtilsDataView.is_ran_ever()
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_ran_last()
+        with self.assertRaises(NotImplementedError):
+            UtilsDataView.is_reset_last()
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -115,6 +119,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_soft_reset())
         self.assertFalse(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -145,6 +150,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertFalse(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -184,6 +190,7 @@ class TestUtilsData(unittest.TestCase):
         # Only set at end of the current run
         self.assertFalse(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             self.assertTrue(UtilsDataView.is_no_stop_requested())
         self.assertFalse(UtilsDataView.is_running())
@@ -219,6 +226,7 @@ class TestUtilsData(unittest.TestCase):
         # Only set at end of the current run
         self.assertFalse(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         self.assertTrue(UtilsDataView.is_no_stop_requested())
         self.assertTrue(UtilsDataView.is_running())
         self.assertTrue(UtilsDataView.is_setup())
@@ -258,6 +266,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_soft_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertTrue(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -287,6 +296,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertTrue(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -313,6 +323,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertTrue(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -351,6 +362,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertTrue(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -382,6 +394,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -409,6 +422,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -448,6 +462,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_soft_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         self.assertTrue(UtilsDataView.is_no_stop_requested())
         self.assertTrue(UtilsDataView.is_running())
         self.assertTrue(UtilsDataView.is_setup())
@@ -502,6 +517,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         self.assertFalse(UtilsDataView.is_no_stop_requested())
         self.assertTrue(UtilsDataView.is_running())
         self.assertTrue(UtilsDataView.is_setup())
@@ -554,6 +570,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_soft_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertTrue(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         self.assertTrue(UtilsDataView.is_no_stop_requested())
         self.assertTrue(UtilsDataView.is_running())
         self.assertTrue(UtilsDataView.is_setup())
@@ -610,6 +627,8 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertTrue(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         self.assertFalse(UtilsDataView.is_no_stop_requested())
         self.assertTrue(UtilsDataView.is_running())
         self.assertTrue(UtilsDataView.is_setup())
@@ -668,6 +687,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertTrue(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -698,6 +718,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -725,6 +746,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -770,6 +792,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(UtilsDataView.is_soft_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         self.assertTrue(UtilsDataView.is_no_stop_requested())
         self.assertTrue(UtilsDataView.is_running())
         self.assertTrue(UtilsDataView.is_setup())
@@ -829,6 +852,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
+        self.assertFalse(UtilsDataView.is_reset_last())
         self.assertFalse(UtilsDataView.is_no_stop_requested())
         self.assertTrue(UtilsDataView.is_running())
         self.assertTrue(UtilsDataView.is_setup())

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -394,7 +394,8 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
-        self.assertFalse(UtilsDataView.is_reset_last())
+        with self.assertRaises(SimulatorShutdownException):
+            UtilsDataView.is_reset_last()
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -422,7 +423,8 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
-        self.assertFalse(UtilsDataView.is_reset_last())
+        with self.assertRaises(SimulatorShutdownException):
+            UtilsDataView.is_reset_last()
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -517,7 +519,8 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
-        self.assertFalse(UtilsDataView.is_reset_last())
+        with self.assertRaises(SimulatorShutdownException):
+            UtilsDataView.is_reset_last()
         self.assertFalse(UtilsDataView.is_no_stop_requested())
         self.assertTrue(UtilsDataView.is_running())
         self.assertTrue(UtilsDataView.is_setup())
@@ -718,7 +721,8 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
-        self.assertFalse(UtilsDataView.is_reset_last())
+        with self.assertRaises(SimulatorShutdownException):
+            UtilsDataView.is_reset_last()
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -746,7 +750,8 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
-        self.assertFalse(UtilsDataView.is_reset_last())
+        with self.assertRaises(SimulatorShutdownException):
+            UtilsDataView.is_reset_last()
         with self.assertRaises(NotImplementedError):
             UtilsDataView.is_no_stop_requested()
         self.assertFalse(UtilsDataView.is_running())
@@ -852,7 +857,8 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(UtilsDataView.is_hard_reset())
         self.assertTrue(UtilsDataView.is_ran_ever())
         self.assertFalse(UtilsDataView.is_ran_last())
-        self.assertFalse(UtilsDataView.is_reset_last())
+        with self.assertRaises(SimulatorShutdownException):
+            UtilsDataView.is_reset_last()
         self.assertFalse(UtilsDataView.is_no_stop_requested())
         self.assertTrue(UtilsDataView.is_running())
         self.assertTrue(UtilsDataView.is_setup())


### PR DESCRIPTION
Adds and tests the is_reset_last method to the view.

This is similar to the ASB.has_reset_last

In that it reports is sim.reset was call since the last sim.run started.

It is different in that the old one still returned True after a sim.stop or sim.end call while the new method raises an exception

---
Note this is different to is_reset_soft or is_reset_hard as they return True during the first run call after the reset