### PR TITLE
View holds requires

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -547,7 +547,7 @@ class UtilsDataView(object):
         Reports if data generation is required
 
         Set to True at the start and by any change that could require
-        data generation and execution to be called
+        data generation or mapping
         Remains True during the first run after a data change
         Only set to False at the END of the first run
 
@@ -572,7 +572,7 @@ class UtilsDataView(object):
 
         Set to True at the start and by any change that could require
         any mapping stage to be called
-        Remains True during the first run after a data change
+        Remains True during the first run after a requires mapping.
         Only set to False at the END of the first run
 
         :rtype: bool
@@ -582,9 +582,10 @@ class UtilsDataView(object):
     @classmethod
     def set_requires_mapping(cls):
         """
-        Sets requires_mapping to True
+        Sets requires_mapping and requires_data_generation to True
 
         Only the end of a run can set it to False
         """
         cls.check_user_can_act()
         cls.__data._requires_mapping = True
+        cls.__data._requires_data_generation = True

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -45,6 +45,8 @@ class _UtilsDataModel(object):
         "_data_status",
         "_executable_finder",
         "_report_dir_path",
+        "_requires_data_generation",
+        "_requires_mapping",
         "_reset_status",
         "_run_dir_path",
         "_run_status",
@@ -68,6 +70,8 @@ class _UtilsDataModel(object):
         """
         Clears out all data
         """
+        self._requires_data_generation = True
+        self._requires_mapping = True
         self._hard_reset()
 
     def _hard_reset(self):
@@ -536,3 +540,51 @@ class UtilsDataView(object):
         """
         return cls.__data._executable_finder.get_executable_paths(
             executable_names)
+
+    @classmethod
+    def get_requires_data_generation(cls):
+        """
+        Reports if data generation is required
+
+        Set to True at the start and by any change that could require
+        data generation and execution to be called
+        Remains True during the first run after a data change
+        Only set to False at the END of the first run
+
+        :rtype: bool
+        """
+        return cls.__data._requires_data_generation
+
+    @classmethod
+    def set_requires_data_generation(cls):
+        """
+        Sets requires_data_generation to True
+
+        Only the end of a run can set it to False
+        """
+        cls.check_user_can_act()
+        cls.__data._requires_data_generation = True
+
+    @classmethod
+    def get_requires_mapping(cls):
+        """
+        Reports if mapping is required
+
+        Set to True at the start and by any change that could require
+        any mapping stage to be called
+        Remains True during the first run after a data change
+        Only set to False at the END of the first run
+
+        :rtype: bool
+        """
+        return cls.__data._requires_mapping
+
+    @classmethod
+    def set_requires_mapping(cls):
+        """
+        Sets requires_mapping to True
+
+        Only the end of a run can set it to False
+        """
+        cls.check_user_can_act()
+        cls.__data._requires_mapping = True

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -70,8 +70,6 @@ class _UtilsDataModel(object):
         """
         Clears out all data
         """
-        self._requires_data_generation = True
-        self._requires_mapping = True
         self._hard_reset()
 
     def _hard_reset(self):
@@ -81,6 +79,8 @@ class _UtilsDataModel(object):
         """
         self._run_dir_path = None
         self._report_dir_path = None
+        self._requires_data_generation = True
+        self._requires_mapping = True
         self._temporary_directory = None
         self._soft_reset()
 

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -153,6 +153,8 @@ class UtilsDataWriter(UtilsDataView):
                 f"{self.__data._run_status}")
         self.__data._run_status = RunStatus.NOT_RUNNING
         self.__data._reset_status = ResetStatus.HAS_RUN
+        self.__data._requires_data_generation = False
+        self.__data._requires_mapping = False
 
     def _hard_reset(self):
         """

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1016,10 +1016,7 @@ class TestUtilsData(unittest.TestCase):
         self.assertFalse(writer.get_requires_data_generation())
         self.assertFalse(writer.get_requires_mapping())
 
-        writer.set_requires_data_generation()
-        self.assertTrue(writer.get_requires_data_generation())
-        self.assertFalse(writer.get_requires_mapping())
-
+        # Setting requires mapping sets both to True
         writer.set_requires_mapping()
         self.assertTrue(writer.get_requires_data_generation())
         self.assertTrue(writer.get_requires_mapping())
@@ -1027,6 +1024,11 @@ class TestUtilsData(unittest.TestCase):
         writer.start_run()
         writer.finish_run()
 
+        # Setting data only sets data
+        writer.set_requires_data_generation()
+        self.assertTrue(writer.get_requires_data_generation())
+        self.assertFalse(writer.get_requires_mapping())
+
         writer.set_requires_mapping()
-        # self.assertTrue(writer.get_requires_data_generation())
+        self.assertTrue(writer.get_requires_data_generation())
         self.assertTrue(writer.get_requires_mapping())

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -994,3 +994,39 @@ class TestUtilsData(unittest.TestCase):
         self.assertEqual(ef, UtilsDataView.get_executable_finder())
         UtilsDataWriter.setup()
         self.assertEqual(ef, UtilsDataView.get_executable_finder())
+
+    def test_requires(self):
+        writer = UtilsDataWriter.setup()
+        # True before run
+        self.assertTrue(writer.get_requires_data_generation())
+        self.assertTrue(writer.get_requires_mapping())
+
+        writer.start_run()
+        # True during first run
+        self.assertTrue(writer.get_requires_data_generation())
+        self.assertTrue(writer.get_requires_mapping())
+        # Can not be changed during run
+        with self.assertRaises(SimulatorRunningException):
+            writer.set_requires_data_generation()
+        with self.assertRaises(SimulatorRunningException):
+            writer.set_requires_mapping()
+        writer.finish_run()
+
+        # False after run
+        self.assertFalse(writer.get_requires_data_generation())
+        self.assertFalse(writer.get_requires_mapping())
+
+        writer.set_requires_data_generation()
+        self.assertTrue(writer.get_requires_data_generation())
+        self.assertFalse(writer.get_requires_mapping())
+
+        writer.set_requires_mapping()
+        self.assertTrue(writer.get_requires_data_generation())
+        self.assertTrue(writer.get_requires_mapping())
+
+        writer.start_run()
+        writer.finish_run()
+
+        writer.set_requires_mapping()
+        # self.assertTrue(writer.get_requires_data_generation())
+        self.assertTrue(writer.get_requires_mapping())


### PR DESCRIPTION
the flags requires_data_generation and requires_mapping where held in many places (vertices, partitions ect) yet if even a single one was True the Mapping or Data Generation has to be redone.
Then all the flags had to be reset.

Instead there is now a single flag for each held in the View.
They can be set to True using the View
Are automatically set back to False at the end of a run.

The flags are True before the first run so will be true if is_ran_ever() is False

vertices_or_edges_added is now part of requires_mapping
AbstractChangableAfterRun no longer needed to identify what may hold these flags

mark_no_changes has been removed or for Population replaced with _reset_has_read_neuron_parameters_this_run

Must be done at the same time as:
https://github.com/SpiNNakerManchester/PACMAN/pull/462
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/973
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1217
https://github.com/SpiNNakerManchester/SpiNNGym/pull/49

tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/133

