### PR TITLE
Mapping dir

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -549,24 +549,6 @@ class UtilsDataView(object):
         raise cls._exception("_dsg_dir_path")
 
     @classmethod
-    def get_report_dir_path(cls):
-        """
-        Returns path to existing reports directory
-
-        ..note: In unittest mode this returns a tempdir
-        shared by all path methods
-
-        :rtpye: str
-        :raises SpiNNUtilsException:
-            If the simulation_time_step is currently unavailable
-        """
-        if cls.__data._report_dir_path:
-            return cls.__data._report_dir_path
-        if cls._is_mocked():
-            return cls._temporary_dir_path()
-        raise cls._exception("report_dir_path")
-
-    @classmethod
     def get_executable_finder(cls):
         """
         The ExcutableFinder object created at time code is imported

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -44,6 +44,7 @@ class _UtilsDataModel(object):
     __slots__ = [
         "_data_status",
         "_executable_finder",
+        "_mapping_dir_path",
         "_report_dir_path",
         "_requires_data_generation",
         "_requires_mapping",
@@ -77,6 +78,7 @@ class _UtilsDataModel(object):
         Puts all data back into the state expected at graph changed and
             sim.reset
         """
+        self._mapping_dir_path = None
         self._run_dir_path = None
         self._report_dir_path = None
         self._requires_data_generation = True
@@ -462,10 +464,18 @@ class UtilsDataView(object):
     @classmethod
     def get_run_dir_path(cls):
         """
-        Returns the path to the directory that holds all the reports for run
+        Returns the path to the directory that holds reports for a run.
 
-        This will be the path used by the last run call or to be used by
-        the next run if it has not yet been called.
+        After a soft reset the run_dir_path changes while the
+        mapping_dir_path does not.
+        So this directory will not hold mapping files and reports
+
+        During run this hold the path for this run.
+
+        Before the first run and after a reset this hold the
+        directory for the next run.
+
+        After a run (not reset) this holds the path from the last run.
 
         ..note: In unittest mode this returns a tempdir
         shared by all path methods
@@ -479,6 +489,34 @@ class UtilsDataView(object):
         if cls._is_mocked():
             return cls._temporary_dir_path()
         raise cls._exception("run_dir_path")
+
+    @classmethod
+    def get_mapping_dir_path(cls):
+        """
+        Returns the path to the directory that holds reports for mapping
+
+        After a soft reset the run_dir_path changes while the
+        mapping_dir_path does not.
+
+        During run this hold the path for this run.
+
+        Before the first run and after a hard reset this hold the
+        directory for the next run.
+
+        After a run (not reset) this holds the path from the last run.
+
+        ..note: In unittest mode this returns a tempdir
+        shared by all path methods
+
+        :rtpye: str
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the run_dir_path is currently unavailable
+        """
+        if cls.__data._mapping_dir_path:
+            return cls.__data._mapping_dir_path
+        if cls._is_mocked():
+            return cls._temporary_dir_path()
+        raise cls._exception("_mapping_dir_path")
 
     @classmethod
     def get_report_dir_path(cls):

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -43,6 +43,7 @@ class _UtilsDataModel(object):
 
     __slots__ = [
         "_data_status",
+        "_dsg_dir_path",
         "_executable_finder",
         "_mapping_dir_path",
         "_report_dir_path",
@@ -78,6 +79,7 @@ class _UtilsDataModel(object):
         Puts all data back into the state expected at graph changed and
             sim.reset
         """
+        self._dsg_dir_path = None
         self._mapping_dir_path = None
         self._run_dir_path = None
         self._report_dir_path = None
@@ -464,7 +466,7 @@ class UtilsDataView(object):
     @classmethod
     def get_run_dir_path(cls):
         """
-        Returns the path to the directory that holds reports for a run.
+        Returns the path to the directory that holds data for a specific run.
 
         After a soft reset the run_dir_path changes while the
         mapping_dir_path does not.
@@ -493,7 +495,7 @@ class UtilsDataView(object):
     @classmethod
     def get_mapping_dir_path(cls):
         """
-        Returns the path to the directory that holds reports for mapping
+        Returns the path to the directory that holds mapping data
 
         After a soft reset the run_dir_path changes while the
         mapping_dir_path does not.
@@ -517,6 +519,34 @@ class UtilsDataView(object):
         if cls._is_mocked():
             return cls._temporary_dir_path()
         raise cls._exception("_mapping_dir_path")
+
+    @classmethod
+    def get_dsg_dir_path(cls):
+        """
+        Returns the path to the directory that dsg holds
+
+        After a soft reset the run_dir_path changes while the
+        mapping_dir_path does not.
+
+        During run this hold the path for this run.
+
+        Before the first run and after a hard reset this hold the
+        directory for the next run.
+
+        After a run (not reset) this holds the path from the last run.
+
+        ..note: In unittest mode this returns a tempdir
+        shared by all path methods
+
+        :rtpye: str
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the run_dir_path is currently unavailable
+        """
+        if cls.__data._dsg_dir_path:
+            return cls.__data._dsg_dir_path
+        if cls._is_mocked():
+            return cls._temporary_dir_path()
+        raise cls._exception("_dsg_dir_path")
 
     @classmethod
     def get_report_dir_path(cls):

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -270,6 +270,21 @@ class UtilsDataWriter(UtilsDataView):
         """
         self.__data._mapping_dir_path = self.__data._run_dir_path
 
+    def get_report_dir_path(self):
+        """
+        Returns path to existing reports directory
+
+        ..note: In unittest mode this returns a tempdir
+        shared by all path methods
+
+        :rtpye: str
+        :raises SpiNNUtilsException:
+            If the simulation_time_step is currently unavailable
+        """
+        if self.__data._report_dir_path:
+            return self.__data._report_dir_path
+        raise self._exception("report_dir_path")
+
     def set_run_dir_path(self, run_dir_path):
         """
         Checks and sets the run_dir_path

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -256,17 +256,22 @@ class UtilsDataWriter(UtilsDataView):
         self.__data._data_status = DataStatus.SHUTDOWN
         self.__data._run_status = RunStatus.SHUTDOWN
 
-    def set_run_dir_path(self, run_dir_path):
+    def set_run_dir_path(self, run_dir_path, mapping_to):
         """
-        Checks and sets the run_dir_path
+        Checks and sets the run_dir_path and if applicable
+        the mapping_dir_path too
 
         :param str run_dir_path:
+        :param bool mapping_to: Falg to say if the mapping dir should change
         :raises InvalidDirectory: if the run_dir_path is not a directory
         """
         if os.path.isdir(run_dir_path):
             self.__data._run_dir_path = run_dir_path
+            if mapping_to:
+                self.__data._mapping_dir_path = run_dir_path
         else:
             self.__data._run_dir_path = None
+            self.__data._mapping_dir_path = None
             raise InvalidDirectory("run_dir_path", run_dir_path)
 
     def set_report_dir_path(self, reports_dir_path):

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -256,22 +256,31 @@ class UtilsDataWriter(UtilsDataView):
         self.__data._data_status = DataStatus.SHUTDOWN
         self.__data._run_status = RunStatus.SHUTDOWN
 
-    def set_run_dir_path(self, run_dir_path, mapping_to):
+    def update_dsg_dir_path(self):
         """
-        Checks and sets the run_dir_path and if applicable
-        the mapping_dir_path too
+        Sets the dsg_dir_path to the run_dir_path
+
+        """
+        self.__data._dsg_dir_path = self.__data._run_dir_path
+
+    def update_mapping_dir_path(self):
+        """
+        Sets the mapping_dir_path to the run_dir_path
+
+        """
+        self.__data._mapping_dir_path = self.__data._run_dir_path
+
+    def set_run_dir_path(self, run_dir_path):
+        """
+        Checks and sets the run_dir_path
 
         :param str run_dir_path:
-        :param bool mapping_to: Falg to say if the mapping dir should change
         :raises InvalidDirectory: if the run_dir_path is not a directory
         """
         if os.path.isdir(run_dir_path):
             self.__data._run_dir_path = run_dir_path
-            if mapping_to:
-                self.__data._mapping_dir_path = run_dir_path
         else:
             self.__data._run_dir_path = None
-            self.__data._mapping_dir_path = None
             raise InvalidDirectory("run_dir_path", run_dir_path)
 
     def set_report_dir_path(self, reports_dir_path):

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -984,22 +984,40 @@ class TestUtilsData(unittest.TestCase):
 
     def test_directories_mocked(self):
         UtilsDataWriter.mock()
-        self.assertTrue(os.path.exists(UtilsDataView.get_run_dir_path))
+        self.assertTrue(os.path.exists(UtilsDataView.get_run_dir_path()))
         self.assertTrue(os.path.exists(UtilsDataView.get_mapping_dir_path()))
+
+    def test_set_dsg_dir_path(self):
+        writer = UtilsDataWriter.setup()
+        writer.setup()
+        with self.assertRaises(DataNotYetAvialable):
+            UtilsDataView.get_dsg_dir_path()
+        writer.set_run_dir_path(os.path.curdir)
+        with self.assertRaises(DataNotYetAvialable):
+            UtilsDataView.get_dsg_dir_path()
+        writer.update_dsg_dir_path()
+        self.assertEqual(os.path.curdir, UtilsDataView.get_dsg_dir_path())
+
+    def test_set_mapping_dir_path(self):
+        writer = UtilsDataWriter.setup()
+        writer.setup()
+        with self.assertRaises(DataNotYetAvialable):
+            UtilsDataView.get_mapping_dir_path()
+        writer.set_run_dir_path(os.path.curdir)
+        with self.assertRaises(DataNotYetAvialable):
+            UtilsDataView.get_mapping_dir_path()
+        writer.update_mapping_dir_path()
+        self.assertEqual(os.path.curdir, UtilsDataView.get_mapping_dir_path())
 
     def test_set_run_dir_path(self):
         writer = UtilsDataWriter.setup()
         writer.setup()
+        with self.assertRaises(DataNotYetAvialable):
+            UtilsDataView.get_run_dir_path()
         with self.assertRaises(InvalidDirectory):
-            writer.set_run_dir_path("bacon", True)
-        writer.set_run_dir_path(os.path.curdir, True)
+            writer.set_run_dir_path("bacon")
+        writer.set_run_dir_path(os.path.curdir)
         self.assertEqual(os.path.curdir, UtilsDataView.get_run_dir_path())
-        self.assertEqual(UtilsDataView.get_run_dir_path(),
-                         UtilsDataView.get_mapping_dir_path())
-        writer.set_run_dir_path(os.path.pardir, False)
-        self.assertEqual(os.path.pardir, UtilsDataView.get_run_dir_path())
-        self.assertNotEqual(UtilsDataView.get_run_dir_path(),
-                            UtilsDataView.get_mapping_dir_path())
 
     def test_set_report_dir_path(self):
         writer = UtilsDataWriter.setup()

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -979,18 +979,27 @@ class TestUtilsData(unittest.TestCase):
         writer.setup()
         with self.assertRaises(DataNotYetAvialable):
             UtilsDataView.get_run_dir_path()
+        with self.assertRaises(DataNotYetAvialable):
+            UtilsDataView.get_mapping_dir_path()
 
     def test_directories_mocked(self):
         UtilsDataWriter.mock()
-        self.assertTrue(os.path.exists(UtilsDataView.get_run_dir_path()))
+        self.assertTrue(os.path.exists(UtilsDataView.get_run_dir_path))
+        self.assertTrue(os.path.exists(UtilsDataView.get_mapping_dir_path()))
 
     def test_set_run_dir_path(self):
         writer = UtilsDataWriter.setup()
         writer.setup()
         with self.assertRaises(InvalidDirectory):
-            writer.set_run_dir_path("bacon")
-        writer.set_run_dir_path(os.path.curdir)
+            writer.set_run_dir_path("bacon", True)
+        writer.set_run_dir_path(os.path.curdir, True)
         self.assertEqual(os.path.curdir, UtilsDataView.get_run_dir_path())
+        self.assertEqual(UtilsDataView.get_run_dir_path(),
+                         UtilsDataView.get_mapping_dir_path())
+        writer.set_run_dir_path(os.path.pardir, False)
+        self.assertEqual(os.path.pardir, UtilsDataView.get_run_dir_path())
+        self.assertNotEqual(UtilsDataView.get_run_dir_path(),
+                            UtilsDataView.get_mapping_dir_path())
 
     def test_set_report_dir_path(self):
         writer = UtilsDataWriter.setup()

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1025,7 +1025,7 @@ class TestUtilsData(unittest.TestCase):
         with self.assertRaises(InvalidDirectory):
             writer.set_report_dir_path("bacon")
         writer.set_report_dir_path(os.path.curdir)
-        self.assertEqual(os.path.curdir, UtilsDataView.get_report_dir_path())
+        self.assertEqual(os.path.curdir, writer.get_report_dir_path())
 
     def test_writer_init_block(self):
         with self.assertRaises(IllegalWriterException):


### PR DESCRIPTION
Please do not merge yet!
Will first try the alternative of having multiple database/files in the same directory.

This PR and associated change it so that the reports/timestamp/run_1 ... directories change with every reset.

- Remember that every time the script has sim.run() the number of the directory changes, even without a reset!

Now with every reset soft or hard there is a new run directory.
-This so the files related to runs are not overridded. Especially buffer.sqlite

Adds a mapping_dir and dsg_dir
Typically these point to the same directory as run_dir.
(So anything that rights can safely use run_dir as writing should only happen when they are the same.

If after a reset requires_mapping is False  the mapping_dir will point to the last run dir when mapping was done.
Readers of mapping files should use therefor should use view get_mapping_dir_path()
"If mapping is not done the run dir will have a  _no_new_mapping.txt pointing to where the mapping files are

Also has a dsg_dir_path for if requires_data_generation is False.
dsg_dir_path == mapping_dir_path IF requires_mapping is TRUE
dsg == run_dir_path if requires_data_generation is False
Otherwise there is a _no_new_dsg file.

get_report_dir_path moved from VIEW to Writer as only places that should be called are to delete old reports and create a new timestamp dir.
Fixed incorrect usages to point to get_run_dir

"provenance" directory has been removed with app / system_provenance_dir moved  directly under the run dir.
 provenance.sqlite3 moved to the mapping_dir (run dir at start or after hard reset)

Dividing provenance.sqlite3 is for future work.
Moving the energy report files is for future work.

Must be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/987
https://github.com/SpiNNakerManchester/JavaSpiNNaker/pull/610
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1228


Tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/152



