### PR TITLE
Test fixes

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -60,7 +60,6 @@ class _UtilsDataModel(object):
         cls.__singleton = obj
         obj._clear()
         obj._data_status = DataStatus.NOT_SETUP
-        obj._executable_finder = ExecutableFinder()
         obj._reset_status = ResetStatus.NOT_SETUP
         obj._run_status = RunStatus.NOT_SETUP
 
@@ -70,6 +69,7 @@ class _UtilsDataModel(object):
         """
         Clears out all data
         """
+        self._executable_finder = ExecutableFinder()
         self._hard_reset()
 
     def _hard_reset(self):

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1013,8 +1013,6 @@ class TestUtilsData(unittest.TestCase):
         writer.finish_run()
         writer.hard_reset()
         self.assertEqual(ef, UtilsDataView.get_executable_finder())
-        UtilsDataWriter.setup()
-        self.assertEqual(ef, UtilsDataView.get_executable_finder())
 
     def test_requires(self):
         writer = UtilsDataWriter.setup()

--- a/unittests/make_tools/test_file_convert.py
+++ b/unittests/make_tools/test_file_convert.py
@@ -125,7 +125,7 @@ class TestConverter(unittest.TestCase):
             assert False
         except Exception as ex1:
             self.assertIn('Unclosed log_info("test %f", -3.0f in ', str(ex1))
-            self.assertIn("mistakes/unclosed.c", str(ex1))
+            self.assertIn("unclosed.c", str(ex1))
 
     def test_semi(self):
         class_file = sys.modules[self.__module__].__file__


### PR DESCRIPTION
small changes to fix tests in windows or where tests/runs interact.

Remove check that depends on file divider

Create a new ExecutableFinder on sim.,setup
(There is one FEC test that has a mock finder which messed up other tests.)

Tested by: