### PR TITLE
Actions updates

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Checkout

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -35,9 +35,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Checkout SupportScripts
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: SpiNNakerManchester/SupportScripts
         path: support


### PR DESCRIPTION
gitthub actions report:
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/setup-python, actions/checkout, actions/checkout, actions/checkout, actions/checkout, actions/setup-python

see: https://github.com/SpiNNakerManchester/SpiNNUtils/actions/runs/3248512597

Fix as shown in:
https://github.com/actions/setup-python

uses: actions/checkout@v3
uses: actions/setup-python@v4

---

Am approval here will be assumed as an an approval to self approve the same change on all other repositories.