### PR TITLE
fix report_dir errors

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -481,24 +481,6 @@ class UtilsDataView(object):
         raise cls._exception("run_dir_path")
 
     @classmethod
-    def get_report_dir_path(cls):
-        """
-        Returns path to existing reports directory
-
-        ..note: In unittest mode this returns a tempdir
-        shared by all path methods
-
-        :rtpye: str
-        :raises SpiNNUtilsException:
-            If the simulation_time_step is currently unavailable
-        """
-        if cls.__data._report_dir_path:
-            return cls.__data._report_dir_path
-        if cls._is_mocked():
-            return cls._temporary_dir_path()
-        raise cls._exception("report_dir_path")
-
-    @classmethod
     def get_executable_finder(cls):
         """
         The ExcutableFinder object created at time code is imported

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -70,6 +70,7 @@ class _UtilsDataModel(object):
         """
         Clears out all data
         """
+        self._report_dir_path = None
         self._hard_reset()
 
     def _hard_reset(self):
@@ -78,7 +79,6 @@ class _UtilsDataModel(object):
             sim.reset
         """
         self._run_dir_path = None
-        self._report_dir_path = None
         self._requires_data_generation = True
         self._requires_mapping = True
         self._temporary_directory = None

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -256,6 +256,24 @@ class UtilsDataWriter(UtilsDataView):
         self.__data._data_status = DataStatus.SHUTDOWN
         self.__data._run_status = RunStatus.SHUTDOWN
 
+    def get_report_dir_path(self):
+        """
+        Returns path to existing reports directory
+
+        This is the high level directory which in which timestamp directories
+        and then run directories are placed.
+
+        As it is only accessed to create timestamp directories and
+        remove old reports this is not a view method.
+
+        :rtpye: str
+        :raises SpiNNUtilsException:
+            If the simulation_time_step is currently unavailable
+        """
+        if self.__data._report_dir_path:
+            return self.__data._report_dir_path
+        raise self._exception("report_dir_path")
+
     def set_run_dir_path(self, run_dir_path):
         """
         Checks and sets the run_dir_path

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1001,7 +1001,7 @@ class TestUtilsData(unittest.TestCase):
         with self.assertRaises(InvalidDirectory):
             writer.set_report_dir_path("bacon")
         writer.set_report_dir_path(os.path.curdir)
-        self.assertEqual(os.path.curdir, UtilsDataView.get_report_dir_path())
+        self.assertEqual(os.path.curdir, writer.get_report_dir_path())
 
     def test_writer_init_block(self):
         with self.assertRaises(IllegalWriterException):


### PR DESCRIPTION
This and related PRs fixes a number of report directory errors.

1. The report directory should not be cleared on a hard reset.
    - it no longer is

2. Only the timestamp directories should go into the report directory 
    - used get_run_dir_pat for all reports
    - Moved the get_run_dir_path to the writer so it can not be used in reports
    - Adjusted tests

3. The bugs where not found in tests
    - extended spynnaker_integration_tests/test_debug_mode 
         - checked each fix before and after so it would have detected any
         - also do a dsg reset and a hard reset
         - check drift report in the correct place
         - other reports changed happen rarely so harder to test
         - Must be extended to check for various sql files when those PRs go in

4. data_speed_up_reports did not get written on run(0)
    - fixed that with a few minor cleanup as well


Related PRs.
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/993
https://github.com/SpiNNakerManchester/PACMAN/pull/477
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1232

tested by:
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1232
https://github.com/SpiNNakerManchester/IntegrationTests/pull/153



