### PR TITLE
Drop support for python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 appdirs
-numpy > 1.13, < 1.20; python_version == '3.6'
 numpy > 1.13, < 1.21; python_version == '3.7'
 numpy; python_version >= '3.8'
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ setup(
     package_data=package_data,
     install_requires=[
         "appdirs",
-        "numpy > 1.13, < 1.20; python_version == '3.6'",
         "numpy > 1.13, < 1.21; python_version == '3.7'",
         "numpy; python_version >= '3.8'",
         "pyyaml",


### PR DESCRIPTION
Drop python 3.6 as described in https://github.com/SpiNNakerManchester/SupportScripts/pull/43