### PR TITLE
Restrict numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     install_requires=[
         "appdirs",
         "numpy > 1.13, < 1.21; python_version == '3.7'",
-        "numpy; python_version >= '3.8'",
+        "numpy < 1.24; python_version >= '3.8'",
         "pyyaml",
         "requests",
     ],


### PR DESCRIPTION
Temporary fix to stop setup.py choosing the recent numpy release candidate which seems to have a problem with pynn / neo.  We could as an alternative go back to including numpy via requirements in repositories instead of doing it this way.