### PR TITLE
Adds a backdoor for unittests

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -584,3 +584,17 @@ class UtilsDataView(object):
         cls.check_user_can_act()
         cls.__data._requires_mapping = True
         cls.__data._requires_data_generation = True
+
+    @classmethod
+    def _mock_has_run(cls):
+        """
+        Mock the status as if run has been called and finished!
+
+        ONLY FOR USE IN UNITTESTS
+
+        Any use outside of unittests is NOT supported and will cause errors!
+        """
+        cls.__data._run_status = RunStatus.NOT_RUNNING
+        cls.__data._reset_status = ResetStatus.HAS_RUN
+        cls.__data._requires_data_generation = False
+        cls.__data._requires_mapping = False


### PR DESCRIPTION
There are unittests that pretend to have run.
They need to HACK the View states so rest of the code thinks it has run.

This adds a method to do that.

Any use outside of unittests will be laughed at!