### PR TITLE
our own strtobool

### DIFF
--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -91,7 +91,7 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         :rtype: int
         """
         value = self.get(section, option)
-        if value.lower() in NONES:
+        if str(value).lower() in NONES:
             return None
         return int(value)
 
@@ -106,7 +106,7 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         :rtype: float
         """
         value = self.get(section, option)
-        if value.lower in NONES:
+        if str(value).lower() in NONES:
             return None
         return float(value)
 
@@ -121,7 +121,7 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         :rtype: bool
         """
         value = self.get(section, option)
-        lower = value.lower()
+        lower = str(value).lower()
         if lower in TRUES:
             return True
         if lower in FALSES:

--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import configparser
-import distutils.util as _du
 
 
 class CamelCaseConfigParser(configparser.RawConfigParser):
@@ -107,6 +106,22 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
             return None
         return float(value)
 
+    @staticmethod
+    def strtobool(val):
+        """Convert a string representation of truth to true (1) or false (0).
+
+        True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+        are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+        'val' is anything else.
+        """
+        val = str(val).lower()
+        if val in ('y', 'yes', 't', 'true', 'on', '1'):
+            return 1
+        elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+            return 0
+        else:
+            raise ValueError("invalid truth value %r" % (val,))
+
     def get_bool(self, section, option):
         """ Get the boolean value of an option.
 
@@ -121,6 +136,6 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         if value == self._none_marker:
             return None
         try:
-            return bool(_du.strtobool(str(value)))
+            return bool(self.strtobool(value))
         except ValueError:
             return bool(value)

--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -16,8 +16,13 @@
 import configparser
 
 
+NONES = ("none", )
+TRUES = ('y', 'yes', 't', 'true', 'on', '1')
+FALSES = ('n', 'no', 'f', 'false', 'off', '0')
+
+
 class CamelCaseConfigParser(configparser.RawConfigParser):
-    __slots__ = ["_none_marker", "_read_files"]
+    __slots__ = ["_read_files"]
 
     def optionxform(self, optionstr):
         """ Transforms the name of an option to lower case and strips\
@@ -26,9 +31,8 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         lower = optionstr.lower()
         return lower.replace("_", "")
 
-    def __init__(self, defaults=None, none_marker="None"):
+    def __init__(self, defaults=None):
         super().__init__(defaults)
-        self._none_marker = none_marker
         self._read_files = list()
 
     def read(self, filenames, encoding=None):
@@ -55,7 +59,7 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         :rtype: str or None
         """
         value = self.get(section, option)
-        if value == self._none_marker:
+        if value.lower() in NONES:
             return None
         return value
 
@@ -69,7 +73,7 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         :rtype: list(str)
         """
         value = self.get(section, option)
-        if value == self._none_marker:
+        if value.lower() in NONES:
             return []
         if len(value.strip()) == 0:
             return []
@@ -87,7 +91,7 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         :rtype: int
         """
         value = self.get(section, option)
-        if value == self._none_marker:
+        if value.lower() in NONES:
             return None
         return int(value)
 
@@ -102,25 +106,9 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         :rtype: float
         """
         value = self.get(section, option)
-        if value == self._none_marker:
+        if value.lower in NONES:
             return None
         return float(value)
-
-    @staticmethod
-    def strtobool(val):
-        """Convert a string representation of truth to true (1) or false (0).
-
-        True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
-        are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
-        'val' is anything else.
-        """
-        val = str(val).lower()
-        if val in ('y', 'yes', 't', 'true', 'on', '1'):
-            return 1
-        elif val in ('n', 'no', 'f', 'false', 'off', '0'):
-            return 0
-        else:
-            raise ValueError("invalid truth value %r" % (val,))
 
     def get_bool(self, section, option):
         """ Get the boolean value of an option.
@@ -133,9 +121,11 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         :rtype: bool
         """
         value = self.get(section, option)
-        if value == self._none_marker:
+        lower = value.lower()
+        if lower in TRUES:
+            return True
+        if lower in FALSES:
+            return False
+        if lower in NONES:
             return None
-        try:
-            return bool(self.strtobool(value))
-        except ValueError:
-            return bool(value)
+        raise ValueError(f"invalid truth value {value}")

--- a/unittests/test_configs.py
+++ b/unittests/test_configs.py
@@ -24,8 +24,7 @@ def test_configs_None():
     set_config("Mode", "Foo", "None")
     set_config("Mode", "Bar", "none")
     assert get_config_str("Mode", "Foo") is None
-    # Don't know if this is desirable but currently None is case sensitive.
-    assert get_config_str("Mode", "bar") == "none"
+    assert get_config_str("Mode", "bar") is None
     assert get_config_int("Mode", "Foo") is None
     assert get_config_float("Mode", "Foo") is None
     assert get_config_bool("Mode", "Foo") is None


### PR DESCRIPTION
Deprecated module 'distutils.util' 

Will be turned off in python 3.12
ref; https://peps.python.org/pep-0632/
recommendation is to do your own strtobool

As this was only used in one place I inlined the code to do exactly what was needed.

Also update so instead of just "None" the case no longer matters.

Also removed the option of adding a customised None marker as it was never used.