### PR TITLE
Revert and fix copyright dates

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 The University of Manchester
+# Copyright (c) 2020 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 The University of Manchester
+# Copyright (c) 2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 
-: Copyright (c) 2017-2023 The University of Manchester
+: Copyright (c) 2017 The University of Manchester
 :
 : Licensed under the Apache License, Version 2.0 (the "License");
 : you may not use this file except in compliance with the License.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2021 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/doc/unfiltered-files.txt
+++ b/doc/unfiltered-files.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2021 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/__init__.py
+++ b/spinn_utilities/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/abstract_base.py
+++ b/spinn_utilities/abstract_base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/abstract_context_manager.py
+++ b/spinn_utilities/abstract_context_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/bytestring_utils.py
+++ b/spinn_utilities/bytestring_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/citation/__init__.py
+++ b/spinn_utilities/citation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/citation/citation_aggregator.py
+++ b/spinn_utilities/citation/citation_aggregator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/citation/citation_updater_and_doi_generator.py
+++ b/spinn_utilities/citation/citation_updater_and_doi_generator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/classproperty.py
+++ b/spinn_utilities/classproperty.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/conf_loader.py
+++ b/spinn_utilities/conf_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/config_setup.py
+++ b/spinn_utilities/config_setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/configs/__init__.py
+++ b/spinn_utilities/configs/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/configs/case_sensitive_parser.py
+++ b/spinn_utilities/configs/case_sensitive_parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/configs/config_template_exception.py
+++ b/spinn_utilities/configs/config_template_exception.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/configs/no_config_found_exception.py
+++ b/spinn_utilities/configs/no_config_found_exception.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/configs/unexpected_config_exception.py
+++ b/spinn_utilities/configs/unexpected_config_exception.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/data/__init__.py
+++ b/spinn_utilities/data/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2021-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/data/data_status.py
+++ b/spinn_utilities/data/data_status.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 The University of Manchester
+# Copyright (c) 2021-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/data/reset_status.py
+++ b/spinn_utilities/data/reset_status.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 The University of Manchester
+# Copyright (c) 2021-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/data/run_status.py
+++ b/spinn_utilities/data/run_status.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 The University of Manchester
+# Copyright (c) 2021-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 The University of Manchester
+# Copyright (c) 2021-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 The University of Manchester
+# Copyright (c) 2021-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/exceptions.py
+++ b/spinn_utilities/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 The University of Manchester
+# Copyright (c) 2019-2020 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/executable_finder.py
+++ b/spinn_utilities/executable_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/find_max_success.py
+++ b/spinn_utilities/find_max_success.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 The University of Manchester
+# Copyright (c) 2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/helpful_functions.py
+++ b/spinn_utilities/helpful_functions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/index_is_value.py
+++ b/spinn_utilities/index_is_value.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/log.py
+++ b/spinn_utilities/log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/log_store.py
+++ b/spinn_utilities/log_store.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/logger_utils.py
+++ b/spinn_utilities/logger_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/make_tools/__init__.py
+++ b/spinn_utilities/make_tools/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/make_tools/converter.py
+++ b/spinn_utilities/make_tools/converter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/make_tools/db.sql
+++ b/spinn_utilities/make_tools/db.sql
@@ -1,4 +1,4 @@
--- Copyright (c) 2018-2023 The University of Manchester
+-- Copyright (c) 2018-2019 The University of Manchester
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/spinn_utilities/make_tools/file_converter.py
+++ b/spinn_utilities/make_tools/file_converter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/make_tools/log_sqllite_database.py
+++ b/spinn_utilities/make_tools/log_sqllite_database.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/make_tools/replacer.py
+++ b/spinn_utilities/make_tools/replacer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/matrix/__init__.py
+++ b/spinn_utilities/matrix/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/matrix/abstract_matrix.py
+++ b/spinn_utilities/matrix/abstract_matrix.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/matrix/demo_matrix.py
+++ b/spinn_utilities/matrix/demo_matrix.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/matrix/double_dict.py
+++ b/spinn_utilities/matrix/double_dict.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/matrix/x_view.py
+++ b/spinn_utilities/matrix/x_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/matrix/y_view.py
+++ b/spinn_utilities/matrix/y_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ordered_set.py
+++ b/spinn_utilities/ordered_set.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/overrides.py
+++ b/spinn_utilities/overrides.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/package_loader.py
+++ b/spinn_utilities/package_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ping.py
+++ b/spinn_utilities/ping.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/progress_bar.py
+++ b/spinn_utilities/progress_bar.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/progress_bar.txt
+++ b/spinn_utilities/progress_bar.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/__init__.py
+++ b/spinn_utilities/ranged/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/abstract_dict.py
+++ b/spinn_utilities/ranged/abstract_dict.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/abstract_list.py
+++ b/spinn_utilities/ranged/abstract_list.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/abstract_sized.py
+++ b/spinn_utilities/ranged/abstract_sized.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/abstract_view.py
+++ b/spinn_utilities/ranged/abstract_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/ids_view.py
+++ b/spinn_utilities/ranged/ids_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/multiple_values_exception.py
+++ b/spinn_utilities/ranged/multiple_values_exception.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/range_dictionary.py
+++ b/spinn_utilities/ranged/range_dictionary.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/ranged_list.py
+++ b/spinn_utilities/ranged/ranged_list.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/ranged_list_of_lists.py
+++ b/spinn_utilities/ranged/ranged_list_of_lists.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 The University of Manchester
+# Copyright (c) 2021 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/single_view.py
+++ b/spinn_utilities/ranged/single_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/ranged/slice_view.py
+++ b/spinn_utilities/ranged/slice_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/require_subclass.py
+++ b/spinn_utilities/require_subclass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 The University of Manchester
+# Copyright (c) 2021 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/safe_eval.py
+++ b/spinn_utilities/safe_eval.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/see.py
+++ b/spinn_utilities/see.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/socket_address.py
+++ b/spinn_utilities/socket_address.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/testing/__init__.py
+++ b/spinn_utilities/testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/testing/log_checker.py
+++ b/spinn_utilities/testing/log_checker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/__init__.py
+++ b/unittests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/__init__.py
+++ b/unittests/abstract_base/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/abstract_grandparent.py
+++ b/unittests/abstract_base/abstract_grandparent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/abstract_has_constraints.py
+++ b/unittests/abstract_base/abstract_has_constraints.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/abstract_has_id.py
+++ b/unittests/abstract_base/abstract_has_id.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/abstract_has_label.py
+++ b/unittests/abstract_base/abstract_has_label.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/abstract_parent.py
+++ b/unittests/abstract_base/abstract_parent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/checked_bad_param.py
+++ b/unittests/abstract_base/checked_bad_param.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/grandparent.py
+++ b/unittests/abstract_base/grandparent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/no_label.py
+++ b/unittests/abstract_base/no_label.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/test_abstract_base.py
+++ b/unittests/abstract_base/test_abstract_base.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/abstract_base/unchecked_bad_param.py
+++ b/unittests/abstract_base/unchecked_bad_param.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/__init__.py
+++ b/unittests/citation/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/c_module/CITATION.cff
+++ b/unittests/citation/c_module/CITATION.cff
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_1_folder/CITATION.cff
+++ b/unittests/citation/package_1_folder/CITATION.cff
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_1_folder/__init__.py
+++ b/unittests/citation/package_1_folder/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_1_folder/c_requirements.txt
+++ b/unittests/citation/package_1_folder/c_requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_1_folder/package_1/__init__.py
+++ b/unittests/citation/package_1_folder/package_1/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_1_folder/requirements.txt
+++ b/unittests/citation/package_1_folder/requirements.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_2_folder/CITATION.cff
+++ b/unittests/citation/package_2_folder/CITATION.cff
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_2_folder/__init__.py
+++ b/unittests/citation/package_2_folder/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_2_folder/package_2/__init__.py
+++ b/unittests/citation/package_2_folder/package_2/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_3_folder/__init__.py
+++ b/unittests/citation/package_3_folder/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_3_folder/package_3/__init__.py
+++ b/unittests/citation/package_3_folder/package_3/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_4_folder/__init__.py
+++ b/unittests/citation/package_4_folder/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_4_folder/package_4/__init__.py
+++ b/unittests/citation/package_4_folder/package_4/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_5_folder/__init__.py
+++ b/unittests/citation/package_5_folder/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/package_5_folder/package_5/__init__.py
+++ b/unittests/citation/package_5_folder/package_5/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/citation/test_citation.py
+++ b/unittests/citation/test_citation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/data/__init__.py
+++ b/unittests/data/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 The University of Manchester
+# Copyright (c) 2021-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/import_all_test.py
+++ b/unittests/import_all_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/make_tools/__init__.py
+++ b/unittests/make_tools/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/make_tools/foo/bar/delta/empty1.c
+++ b/unittests/make_tools/foo/bar/delta/empty1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 The University of Manchester
+ * Copyright (c) 2019 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/foo/bar/gamma/foo/empty.c
+++ b/unittests/make_tools/foo/bar/gamma/foo/empty.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 The University of Manchester
+ * Copyright (c) 2019 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/formats.c1
+++ b/unittests/make_tools/formats.c1
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 The University of Manchester
+ * Copyright (c) 2013-2018 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/formats.c2
+++ b/unittests/make_tools/formats.c2
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 The University of Manchester
+ * Copyright (c) 2013-2018 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mistakes/bad_comma.c
+++ b/unittests/make_tools/mistakes/bad_comma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 The University of Manchester
+ * Copyright (c) 2022 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mistakes/bad_format.c
+++ b/unittests/make_tools/mistakes/bad_format.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 The University of Manchester
+ * Copyright (c) 2022 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mistakes/open.c
+++ b/unittests/make_tools/mistakes/open.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 The University of Manchester
+ * Copyright (c) 2022 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mistakes/semi.c
+++ b/unittests/make_tools/mistakes/semi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 The University of Manchester
+ * Copyright (c) 2022 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mistakes/too_few.c
+++ b/unittests/make_tools/mistakes/too_few.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 The University of Manchester
+ * Copyright (c) 2022 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mistakes/too_many.c
+++ b/unittests/make_tools/mistakes/too_many.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 The University of Manchester
+ * Copyright (c) 2022 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mistakes/unclosed.c
+++ b/unittests/make_tools/mistakes/unclosed.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 The University of Manchester
+ * Copyright (c) 2022 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mock_src/bit_field.c
+++ b/unittests/make_tools/mock_src/bit_field.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 The University of Manchester
+ * Copyright (c) 2013-2018 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mock_src/common-typedefs.h
+++ b/unittests/make_tools/mock_src/common-typedefs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2023 The University of Manchester
+ * Copyright (c) 2013-2018 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/mock_src/weird,file.c
+++ b/unittests/make_tools/mock_src/weird,file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 The University of Manchester
+ * Copyright (c) 2018 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/unittests/make_tools/test_convert.py
+++ b/unittests/make_tools/test_convert.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/make_tools/test_file_convert.py
+++ b/unittests/make_tools/test_file_convert.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/make_tools/test_replacer.py
+++ b/unittests/make_tools/test_replacer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/matrix/__init__.py
+++ b/unittests/matrix/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/matrix/test_double.py
+++ b/unittests/matrix/test_double.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/matrix/test_matrix.py
+++ b/unittests/matrix/test_matrix.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/__init__.py
+++ b/unittests/ranged/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/dual_test.py
+++ b/unittests/ranged/dual_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/ids_test.py
+++ b/unittests/ranged/ids_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/single_list_test.py
+++ b/unittests/ranged/single_list_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/single_over_none_list_test.py
+++ b/unittests/ranged/single_over_none_list_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/single_view_test.py
+++ b/unittests/ranged/single_view_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/slice_test.py
+++ b/unittests/ranged/slice_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/test_list.py
+++ b/unittests/ranged/test_list.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/test_non_ranged_list.py
+++ b/unittests/ranged/test_non_ranged_list.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/test_numpy.py
+++ b/unittests/ranged/test_numpy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/test_ranged_list_of_lists.py
+++ b/unittests/ranged/test_ranged_list_of_lists.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/test_views_ids.py
+++ b/unittests/ranged/test_views_ids.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/ranged/whole_test.py
+++ b/unittests/ranged/whole_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_bytestring_utils.py
+++ b/unittests/test_bytestring_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_class_property.py
+++ b/unittests/test_class_property.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_conf_loader.py
+++ b/unittests/test_conf_loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_configs.py
+++ b/unittests/test_configs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_context_manager.py
+++ b/unittests/test_context_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 The University of Manchester
+# Copyright (c) 2020 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_exec_finder.py
+++ b/unittests/test_exec_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_helpful_functions.py
+++ b/unittests/test_helpful_functions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_index_is_value.py
+++ b/unittests/test_index_is_value.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_log.py
+++ b/unittests/test_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_log_checker.py
+++ b/unittests/test_log_checker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2022 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_logger_utils.py
+++ b/unittests/test_logger_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_ordered_set.py
+++ b/unittests/test_ordered_set.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_overrides.py
+++ b/unittests/test_overrides.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_ping.py
+++ b/unittests/test_ping.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_progress_bar.py
+++ b/unittests/test_progress_bar.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_require_subclass.py
+++ b/unittests/test_require_subclass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018-2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_safe_eval.py
+++ b/unittests/test_safe_eval.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_search_for_max_success.py
+++ b/unittests/test_search_for_max_success.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 The University of Manchester
+# Copyright (c) 2019 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_see.py
+++ b/unittests/test_see.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_socket_address.py
+++ b/unittests/test_socket_address.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 The University of Manchester
+# Copyright (c) 2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/unittests/test_timer.py
+++ b/unittests/test_timer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 The University of Manchester
+# Copyright (c) 2017-2018 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This fix too aggressive change in copy right dates.

The original changed used the git add date but many files where started by copying in another just to get the headers,
This meant many files where changed to early.

The script had also changed the end copyright date on all files to 2023.
However as others feel it is better to only change the end date manually on significant changes this was reverted.

