### PR TITLE
Requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -20,5 +20,4 @@ pytest-cov
 testfixtures
 sphinx >= 2
 pyyaml
-requests
 httpretty != 1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@
 
 appdirs
 numpy > 1.13, < 1.21; python_version == '3.7'
-numpy; python_version >= '3.8'
+numpy < 1.24; python_version >= '3.8'
 pyyaml
 requests >= 2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ appdirs
 numpy > 1.13, < 1.21; python_version == '3.7'
 numpy; python_version >= '3.8'
 pyyaml
-requests
+requests >= 2.4.1

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         "numpy > 1.13, < 1.21; python_version == '3.7'",
         "numpy < 1.24; python_version >= '3.8'",
         "pyyaml",
-        "requests",
+        "requests >= 2.4.1",
     ],
     maintainer="SpiNNakerTeam",
     maintainer_email="spinnakerusers@googlegroups.com"


### PR DESCRIPTION
The cap on numpy is required for neo https://github.com/SpiNNakerManchester/SpiNNUtils/issues/206
so keep requirements.txt and setup the same.

The min on requests come from elsewhere