### PR TITLE
Support Numpy array as selector

### DIFF
--- a/spinn_utilities/ranged/abstract_list.py
+++ b/spinn_utilities/ranged/abstract_list.py
@@ -205,8 +205,6 @@ class AbstractList(AbstractSized, metaclass=AbstractBase):
             return self.get_value_by_id(selector)
         else:
             return [self.get_value_by_id(i) for i in selector]
-        #else:
-        #    raise TypeError(f"Invalid argument type: {type(selector)}")
 
     def iter_by_id(self, the_id):
         """ Fast but *not* update-safe iterator by one ID.

--- a/spinn_utilities/ranged/abstract_list.py
+++ b/spinn_utilities/ranged/abstract_list.py
@@ -197,14 +197,16 @@ class AbstractList(AbstractSized, metaclass=AbstractBase):
             return [self[i] for i in range(*selector.indices(self._size))]
 
         # If the key is an int, get the single value
-        elif isinstance(selector, int):
+        elif isinstance(selector, (int, numpy.integer)):
 
             # Handle negative indices
             if selector < 0:
                 selector += len(self)
             return self.get_value_by_id(selector)
         else:
-            raise TypeError("Invalid argument type.")
+            return [self.get_value_by_id(i) for i in selector]
+        #else:
+        #    raise TypeError(f"Invalid argument type: {type(selector)}")
 
     def iter_by_id(self, the_id):
         """ Fast but *not* update-safe iterator by one ID.

--- a/spinn_utilities/ranged/ranged_list.py
+++ b/spinn_utilities/ranged/ranged_list.py
@@ -281,7 +281,8 @@ class RangedList(AbstractList):
         else:
             values = list(value)
         if len(values) != size:
-            raise ValueError("The number of values does not equal the size")
+            raise ValueError(f"The number of values:{len(values)} "
+                             f"does not equal the size:{size}")
         return values
 
     def set_value(self, value, use_list_as_value=False):

--- a/unittests/ranged/test_list.py
+++ b/unittests/ranged/test_list.py
@@ -249,6 +249,7 @@ def test_iter_by_ids():
     assert rl[0:5] == ["a", "a", "a", "a", "a"]
     assert list(rl.iter_by_ids([9, 1, 2, 5])) == ["b", "a", "a", "b"]
 
+
 def test_iter_by_numpy():
     rl = RangedList(size=10, value="a", key="alpha")
     first = numpy.array([0, 1, 2, 3, 4])
@@ -257,7 +258,8 @@ def test_iter_by_numpy():
     assert rl[second] == ["b", "b", "b", "b", "b"]
     assert rl[first] == ["a", "a", "a", "a", "a"]
     weird = numpy.array([9, 1, 2, 5])
-    assert list(rl.iter_by_ids([9, 1, 2, 5])) == ["b", "a", "a", "b"]
+    assert list(rl.iter_by_ids(weird)) == ["b", "a", "a", "b"]
+
 
 def test_set_value_by_slice():
     rl = RangedList(size=10, value="a", key="alpha")

--- a/unittests/ranged/test_list.py
+++ b/unittests/ranged/test_list.py
@@ -249,6 +249,15 @@ def test_iter_by_ids():
     assert rl[0:5] == ["a", "a", "a", "a", "a"]
     assert list(rl.iter_by_ids([9, 1, 2, 5])) == ["b", "a", "a", "b"]
 
+def test_iter_by_numpy():
+    rl = RangedList(size=10, value="a", key="alpha")
+    first = numpy.array([0, 1, 2, 3, 4])
+    second = numpy.array([5, 6, 7, 8, 9])
+    rl[second] = "b"
+    assert rl[second] == ["b", "b", "b", "b", "b"]
+    assert rl[first] == ["a", "a", "a", "a", "a"]
+    weird = numpy.array([9, 1, 2, 5])
+    assert list(rl.iter_by_ids([9, 1, 2, 5])) == ["b", "a", "a", "b"]
 
 def test_set_value_by_slice():
     rl = RangedList(size=10, value="a", key="alpha")
@@ -334,6 +343,8 @@ def test_bad_ids():
         rl.get_value_by_id(None)
     with pytest.raises(TypeError):
         rl["a"]
+    with pytest.raises(TypeError):
+        rl[2.3]
 
 
 def test_str():


### PR DESCRIPTION
If we want to allow rater_ids which are a Numpy array as indexes into a RangedList we have to support it.

Also improves an error message.


Can be safely merged before any other PR that makes use of it as only adds functionality

