### PR TITLE
License :: OSI Approved :: Apache Software License

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers=
         Development Status :: 5 - Production/Stable
         Intended Audience :: Developers
         Intended Audience :: Science/Research
-        License :: OSI Approved :: Apache License 2.0
+        License :: OSI Approved :: Apache Software License
         Natural Language :: English
         Operating System :: POSIX :: Linux
         Operating System :: Microsoft :: Windows


### PR DESCRIPTION
The classifier License in setupy must be:

 License :: OSI Approved :: Apache Software License

is is the only Apache one allowed.

ref:
https://github.com/pypa/trove-classifiers/issues/17

Trying the original gave:
Invalid value for classifiers. Error: Classifier 'License :: OSI Approved :: Apache-2.0' is not a valid classifier.                                                             
        
I also got
Invalid value for classifiers. Error: Classifier 'License :: OSI Approved :: Apache Software License 2.0 (Apache-2.0)' is not a valid classifier. 

