### PR TITLE
Remove requires data generation

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -44,7 +44,6 @@ class _UtilsDataModel(object):
         "_data_status",
         "_executable_finder",
         "_report_dir_path",
-        "_requires_data_generation",
         "_requires_mapping",
         "_reset_status",
         "_run_dir_path",
@@ -78,7 +77,6 @@ class _UtilsDataModel(object):
         `sim.reset`.
         """
         self._run_dir_path = None
-        self._requires_data_generation = True
         self._requires_mapping = True
         self._temporary_directory = None
         self._soft_reset()
@@ -545,30 +543,6 @@ class UtilsDataView(object):
             executable_names)
 
     @classmethod
-    def get_requires_data_generation(cls):
-        """
-        Reports if data generation is required.
-
-        Set to True at the start and by any change that could require
-        data generation or mapping
-        Remains True during the first run after a data change
-        Only set to False at the *end* of the first run
-
-        :rtype: bool
-        """
-        return cls.__data._requires_data_generation
-
-    @classmethod
-    def set_requires_data_generation(cls):
-        """
-        Sets `requires_data_generation` to True.
-
-        Only the end of a run can set it to False
-        """
-        cls.check_user_can_act()
-        cls.__data._requires_data_generation = True
-
-    @classmethod
     def get_requires_mapping(cls):
         """
         Reports if mapping is required.
@@ -585,13 +559,12 @@ class UtilsDataView(object):
     @classmethod
     def set_requires_mapping(cls):
         """
-        Sets `requires_mapping` and `requires_data_generation` to True.
+        Sets `requires_mapping` to True.
 
         Only the end of a run can set it to False
         """
         cls.check_user_can_act()
         cls.__data._requires_mapping = True
-        cls.__data._requires_data_generation = True
 
     @classmethod
     def _mock_has_run(cls):
@@ -607,5 +580,4 @@ class UtilsDataView(object):
         """
         cls.__data._run_status = RunStatus.NOT_RUNNING
         cls.__data._reset_status = ResetStatus.HAS_RUN
-        cls.__data._requires_data_generation = False
         cls.__data._requires_mapping = False

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -147,7 +147,6 @@ class UtilsDataWriter(UtilsDataView):
                 f"{self.__data._run_status}")
         self.__data._run_status = RunStatus.NOT_RUNNING
         self.__data._reset_status = ResetStatus.HAS_RUN
-        self.__data._requires_data_generation = False
         self.__data._requires_mapping = False
 
     def _hard_reset(self):

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1021,12 +1021,10 @@ class TestUtilsData(unittest.TestCase):
     def test_requires(self):
         writer = UtilsDataWriter.setup()
         # True before run
-        self.assertTrue(writer.get_requires_data_generation())
         self.assertTrue(writer.get_requires_mapping())
 
         writer.start_run()
         # True during first run
-        self.assertTrue(writer.get_requires_data_generation())
         self.assertTrue(writer.get_requires_mapping())
         # Can not be changed during run
         with self.assertRaises(SimulatorRunningException):
@@ -1034,17 +1032,14 @@ class TestUtilsData(unittest.TestCase):
         writer.finish_run()
 
         # False after run
-        self.assertFalse(writer.get_requires_data_generation())
         self.assertFalse(writer.get_requires_mapping())
 
         # Setting requires mapping sets both to True
         writer.set_requires_mapping()
-        self.assertTrue(writer.get_requires_data_generation())
         self.assertTrue(writer.get_requires_mapping())
 
         writer.start_run()
         writer.finish_run()
 
         writer.set_requires_mapping()
-        self.assertTrue(writer.get_requires_data_generation())
         self.assertTrue(writer.get_requires_mapping())

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1030,8 +1030,6 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(writer.get_requires_mapping())
         # Can not be changed during run
         with self.assertRaises(SimulatorRunningException):
-            writer.set_requires_data_generation()
-        with self.assertRaises(SimulatorRunningException):
             writer.set_requires_mapping()
         writer.finish_run()
 
@@ -1046,11 +1044,6 @@ class TestUtilsData(unittest.TestCase):
 
         writer.start_run()
         writer.finish_run()
-
-        # Setting data only sets data
-        writer.set_requires_data_generation()
-        self.assertTrue(writer.get_requires_data_generation())
-        self.assertFalse(writer.get_requires_mapping())
 
         writer.set_requires_mapping()
         self.assertTrue(writer.get_requires_data_generation())


### PR DESCRIPTION
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1338 removes the only use of requires_mapping as it is currently not working.

With that use case gone the whole requires mapping can go.

Must be done at the same time or after:

