### PR TITLE
Add a bool instead of using None for needs loading

### DIFF
--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -24,7 +24,7 @@ from spinn_utilities.log import FormatAdapter
 logger = FormatAdapter(logging.getLogger(__file__))
 
 __config: CamelCaseConfigParser = CamelCaseConfigParser()
-__needs_loading:bool = True
+__needs_loading: bool = True
 __default_config_files: List[str] = []
 __config_file: Optional[str] = None
 __unittest_mode: bool = False
@@ -101,6 +101,7 @@ def load_config() -> None:
         for default in __default_config_files:
             __config.read(default)
     __needs_loading = False
+
 
 def get_config_str(section: str, option: str) -> Optional[str]:
     """

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -110,7 +110,7 @@ def get_config_str(section: str, option: str) -> Optional[str]:
     :return: The option value
     :rtype: str or None
     """
-    if __config is not None:
+    if __config is None:
         _pre_load_config()
     return __config.get_str(section, option)
 

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -50,7 +50,7 @@ def clear_cfg_files(unittest_mode: bool):
     :param bool unittest_mode: Flag to put the holder into unit testing mode
     """
     global __config, __config_file, __needs_loading, __unittest_mode
-    __config = None
+    __config = CamelCaseConfigParser()
     __default_config_files.clear()
     __config_file = None
     __needs_loading = True
@@ -100,7 +100,7 @@ def load_config() -> None:
     else:
         for default in __default_config_files:
             __config.read(default)
-
+    __needs_loading = False
 
 def get_config_str(section: str, option: str) -> Optional[str]:
     """

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -110,14 +110,8 @@ def get_config_str(section: str, option: str) -> Optional[str]:
     :return: The option value
     :rtype: str or None
     """
-    try:
-        if __config is not None:
-            return __config.get_str(section, option)
-    except AttributeError:
-        pass
-    _pre_load_config()
-    if __config is None:
-        raise ConfigException("configuration not loaded")
+    if __config is not None:
+        _pre_load_config()
     return __config.get_str(section, option)
 
 


### PR DESCRIPTION
Option 1:
This Pr removes the 
Optional from __config: 
- By setting it to an Empty Config
- tracking the need to load in a seperate boolean

For Option 2 see:
https://github.com/SpiNNakerManchester/SpiNNUtils/pull/238