### PR TITLE
Is config none

### DIFF
--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -100,6 +100,19 @@ def load_config():
             __config.read(default)
 
 
+def is_config_none(section, option):
+    """
+    Check if the value of a configuration option would be considered None
+
+    :param str section: What section to get the option from.
+    :param str option: What option to read.
+    :return: True if and only if the value would be considered None
+    :rtype: bool
+    """
+    value = get_config_str_or_none(section, option)
+    return value is None
+
+
 def get_config_str(section, option):
     """
     Get the string value of a configuration option.
@@ -107,7 +120,24 @@ def get_config_str(section, option):
     :param str section: What section to get the option from.
     :param str option: What option to read.
     :return: The option value
+    :rtype: str
+    :raises ConfigException: if the Value would be None
+    """
+    value = get_config_str_or_none(section, option)
+    if value is None:
+        raise ConfigException(f"Unexpected None for {section=} {option=}")
+    return value
+
+
+def get_config_str_or_none(section, option):
+    """
+    Get the string value of a configuration option.
+
+    :param str section: What section to get the option from.
+    :param str option: What option to read.
+    :return: The option value
     :rtype: str or None
+    :raises ConfigException: if the Value would be None
     """
     try:
         return __config.get_str(section, option)
@@ -143,6 +173,23 @@ def get_config_int(section, option):
     :param str option: What option to read.
     :return: The option value
     :rtype: int
+    :raises ConfigException: if the Value would be None
+    """
+    value = get_config_int_or_none(section, option)
+    if value is None:
+        raise ConfigException(f"Unexpected None for {section=} {option=}")
+    return value
+
+
+def get_config_int_or_none(section, option):
+    """
+    Get the integer value of a configuration option.
+
+    :param str section: What section to get the option from.
+    :param str option: What option to read.
+    :return: The option value
+    :rtype: int or None
+    :raises ConfigException: if the Value would be None
     """
     try:
         return __config.get_int(section, option)
@@ -160,6 +207,22 @@ def get_config_float(section, option):
     :param str option: What option to read.
     :return: The option value.
     :rtype: float
+    :raises ConfigException: if the Value would be None
+    """
+    value = get_config_float_or_none(section, option)
+    if value is None:
+        raise ConfigException(f"Unexpected None for {section=} {option=}")
+    return value
+
+
+def get_config_float_or_none(section, option):
+    """
+    Get the float value of a configuration option.
+
+    :param str section: What section to get the option from.
+    :param str option: What option to read.
+    :return: The option value.
+    :rtype: float or None
     """
     try:
         return __config.get_float(section, option)
@@ -177,6 +240,23 @@ def get_config_bool(section, option):
     :param str option: What option to read.
     :return: The option value.
     :rtype: bool
+    :raises ConfigException: if the Value would be None
+    """
+    value = get_config_bool_or_none(section, option)
+    if value is None:
+        raise ConfigException(f"Unexpected None for {section=} {option=}")
+    return value
+
+
+def get_config_bool_or_none(section, option):
+    """
+    Get the boolean value of a configuration option.
+
+    :param str section: What section to get the option from.
+    :param str option: What option to read.
+    :return: The option value.
+    :rtype: bool
+    :raises ConfigException: if the Value would be None
     """
     try:
         return __config.get_bool(section, option)
@@ -279,13 +359,17 @@ def _check_python_file(py_path):
         lines = py_file.readlines()
         for index, line in enumerate(lines):
             if "get_config_bool(" in line:
-                _check_lines(py_path, line, lines, index, get_config_bool)
+                _check_lines(
+                    py_path, line, lines, index, get_config_bool_or_none)
             if "get_config_float(" in line:
-                _check_lines(py_path, line, lines, index, get_config_float)
+                _check_lines(
+                    py_path, line, lines, index, get_config_float_or_none)
             if "get_config_int(" in line:
-                _check_lines(py_path, line, lines, index, get_config_int)
+                _check_lines(
+                    py_path, line, lines, index, get_config_int_or_none)
             if "get_config_str(" in line:
-                _check_lines(py_path, line, lines, index, get_config_str)
+                _check_lines(
+                    py_path, line, lines, index, get_config_str_or_none)
             if "get_config_str_list(" in line:
                 _check_lines(py_path, line, lines, index, get_config_str_list)
 

--- a/spinn_utilities/socket_address.py
+++ b/spinn_utilities/socket_address.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from spinn_utilities.config_holder import get_config_int, get_config_str
+from spinn_utilities.config_holder import (
+    get_config_int, get_config_int_or_none, get_config_str)
 
 
 class SocketAddress(object):
@@ -50,7 +51,7 @@ class SocketAddress(object):
         else:
             notify_host_name = str(notify_host_name)
         if listen_port is None:
-            listen_port = get_config_int("Database", "listen_port")
+            listen_port = get_config_int_or_none("Database", "listen_port")
         else:
             listen_port = int(listen_port)
         self._notify_host_name = notify_host_name

--- a/unittests/test_configs.py
+++ b/unittests/test_configs.py
@@ -14,7 +14,8 @@
 
 from spinn_utilities.config_setup import unittest_setup
 from spinn_utilities.config_holder import (
-    get_config_bool, get_config_float_or_none, get_config_int_or_none,
+    get_config_bool, get_config_bool_or_none, get_config_float,
+    get_config_float_or_none, get_config_int, get_config_int_or_none,
     get_config_str, get_config_str_or_none,  set_config)
 from spinn_utilities.exceptions import ConfigException, SpiNNUtilsException
 
@@ -24,12 +25,27 @@ def test_configs_None():
     set_config("Mode", "Foo", "None")
     set_config("Mode", "Bar", "none")
     assert get_config_str_or_none("Mode", "Foo") is None
-    assert get_config_str_or_none("Mode", "bar") is None
-    assert get_config_int_or_none("Mode", "Foo") is None
-    assert get_config_float_or_none("Mode", "Foo") is None
-    #assert get_config_bool("Mode", "Foo") is None
     try:
         assert get_config_str("Mode", "Foo") is None
+        raise SpiNNUtilsException("Expected ConfigException")
+    except ConfigException:
+        pass
+    assert get_config_str_or_none("Mode", "bar") is None
+    assert get_config_int_or_none("Mode", "Foo") is None
+    try:
+        assert get_config_int("Mode", "Foo") is None
+        raise SpiNNUtilsException("Expected ConfigException")
+    except ConfigException:
+        pass
+    assert get_config_float_or_none("Mode", "Foo") is None
+    try:
+        assert get_config_float("Mode", "Foo") is None
+        raise SpiNNUtilsException("Expected ConfigException")
+    except ConfigException:
+        pass
+    assert get_config_bool_or_none("Mode", "Foo") is None
+    try:
+        assert get_config_bool("Mode", "Foo") is None
         raise SpiNNUtilsException("Expected ConfigException")
     except ConfigException:
         pass

--- a/unittests/test_configs.py
+++ b/unittests/test_configs.py
@@ -14,16 +14,22 @@
 
 from spinn_utilities.config_setup import unittest_setup
 from spinn_utilities.config_holder import (
-    get_config_bool, get_config_float, get_config_int, get_config_str,
-    set_config)
+    get_config_bool, get_config_float_or_none, get_config_int_or_none,
+    get_config_str, get_config_str_or_none,  set_config)
+from spinn_utilities.exceptions import ConfigException, SpiNNUtilsException
 
 
 def test_configs_None():
     unittest_setup()
     set_config("Mode", "Foo", "None")
     set_config("Mode", "Bar", "none")
-    assert get_config_str("Mode", "Foo") is None
-    assert get_config_str("Mode", "bar") is None
-    assert get_config_int("Mode", "Foo") is None
-    assert get_config_float("Mode", "Foo") is None
-    assert get_config_bool("Mode", "Foo") is None
+    assert get_config_str_or_none("Mode", "Foo") is None
+    assert get_config_str_or_none("Mode", "bar") is None
+    assert get_config_int_or_none("Mode", "Foo") is None
+    assert get_config_float_or_none("Mode", "Foo") is None
+    #assert get_config_bool("Mode", "Foo") is None
+    try:
+        assert get_config_str("Mode", "Foo") is None
+        raise SpiNNUtilsException("Expected ConfigException")
+    except ConfigException:
+        pass


### PR DESCRIPTION
Split config methods into those that can provide None and those that will error.

Will need to be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNMachine/pull/222
https://github.com/SpiNNakerManchester/SpiNNMan/pull/360
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1108
https://github.com/SpiNNakerManchester/TestBase/pull/49
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1382
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/259

tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/233

