### PR TITLE
simplify AbstractContextManager

### DIFF
--- a/spinn_utilities/abstract_context_manager.py
+++ b/spinn_utilities/abstract_context_manager.py
@@ -28,27 +28,9 @@ class AbstractContextManager(object, metaclass=AbstractBase):
         How to actually close the underlying resources.
         """
 
-    def _context_entered(self):
-        """
-        Called when the context is entered. The result is ignored.
-        """
-
-    def _context_exception_occurred(self, exc_type, exc_val, exc_tb):
-        """
-        Called when an exception occurs during the `with` context, *after*
-        the context has been closed.
-
-        :param type exc_type:
-        :param object exc_val:
-        :param traceback exc_tb:
-        """
-
     def __enter__(self):
-        self._context_entered()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
-        if exc_type:
-            self._context_exception_occurred(exc_type, exc_val, exc_tb)
         return False

--- a/unittests/test_context_manager.py
+++ b/unittests/test_context_manager.py
@@ -17,16 +17,10 @@ from spinn_utilities.abstract_context_manager import AbstractContextManager
 
 class CM(AbstractContextManager):
     def __init__(self):
-        self.state = None
-
-    def _context_entered(self):
-        self.state = 0
+        self.state = "open"
 
     def close(self):
-        self.state += 1
-
-    def _context_exception_occurred(self, exc_type, exc_val, exc_tb):
-        self.state = str(exc_val)
+        self.state = "closed"
 
 
 class CMTestExn(Exception):
@@ -40,18 +34,4 @@ def test_acm_with_success():
     with cm:
         states.append(cm.state)
     states.append(cm.state)
-    assert states == [None, 0, 1]
-
-
-def test_acm_with_exception():
-    states = []
-    cm = CM()
-    try:
-        states.append(cm.state)
-        with cm:
-            states.append(cm.state)
-            raise CMTestExn("boo")
-    except CMTestExn:
-        pass
-    states.append(cm.state)
-    assert states == [None, 0, "boo"]
+    assert states == ["open",  "open", "closed"]


### PR DESCRIPTION
AbstractContextManager is used but not as expected.

The only class that overrides _context_entered (SQLiteDB) also overrides exist.
So in SQLiteDB enter and exit are now implemented directly

No class overirdes _context_exception_occurred so this method makes no sense.

Keeping a simplified AbstractContextManager is needed as Spalloc pass these around and there is not better definition / Abstract

Must be done after https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1130

related work can be done before or after
https://github.com/SpiNNakerManchester/SpiNNMan/pull/368
https://github.com/SpiNNakerManchester/spalloc/pull/88

