### PR TITLE
Fix unit failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 /.settings
 .DS_Store
 .idea/
+/.mypy_cache/

--- a/unittests/make_tools/.gitignore
+++ b/unittests/make_tools/.gitignore
@@ -3,5 +3,5 @@ test_ranges.txt
 /log.ranges
 alpha
 logs.sqlite3
-convert.sqlite3
-
+convert_1.sqlite3
+convert_2.sqlite3

--- a/unittests/make_tools/test_convert.py
+++ b/unittests/make_tools/test_convert.py
@@ -28,7 +28,7 @@ class TestConverter(unittest.TestCase):
         class_file = sys.modules[self.__module__].__file__
         path = os.path.dirname(os.path.abspath(class_file))
         os.chdir(path)
-        os.environ["C_LOGS_DICT"] = str(os.path.join(path, "convert.sqlite3"))
+        os.environ["C_LOGS_DICT"] = str(os.path.join(path, "convert_1.sqlite3"))
         # Clear the database
         LogSqlLiteDatabase(True)
         src = "mock_src"

--- a/unittests/make_tools/test_convert.py
+++ b/unittests/make_tools/test_convert.py
@@ -28,7 +28,8 @@ class TestConverter(unittest.TestCase):
         class_file = sys.modules[self.__module__].__file__
         path = os.path.dirname(os.path.abspath(class_file))
         os.chdir(path)
-        os.environ["C_LOGS_DICT"] = str(os.path.join(path, "convert_1.sqlite3"))
+        os.environ["C_LOGS_DICT"] = str(os.path.join(path,
+                                                     "convert_1.sqlite3"))
         # Clear the database
         LogSqlLiteDatabase(True)
         src = "mock_src"

--- a/unittests/make_tools/test_file_convert.py
+++ b/unittests/make_tools/test_file_convert.py
@@ -27,7 +27,8 @@ class TestConverter(unittest.TestCase):
     def test_convert(self):
         class_file = sys.modules[self.__module__].__file__
         path = os.path.dirname(os.path.abspath(class_file))
-        os.environ["C_LOGS_DICT"] = str(os.path.join(path, "convert_2.sqlite3"))
+        os.environ["C_LOGS_DICT"] = str(os.path.join(path,
+                                                     "convert_2.sqlite3"))
         file_name = "weird,file.c"
         src = os.path.join(path, "mock_src")
         dest = os.path.join(path, "modified_src")

--- a/unittests/make_tools/test_file_convert.py
+++ b/unittests/make_tools/test_file_convert.py
@@ -27,7 +27,7 @@ class TestConverter(unittest.TestCase):
     def test_convert(self):
         class_file = sys.modules[self.__module__].__file__
         path = os.path.dirname(os.path.abspath(class_file))
-        os.environ["C_LOGS_DICT"] = str(os.path.join(path, "convert.sqlite3"))
+        os.environ["C_LOGS_DICT"] = str(os.path.join(path, "convert_2.sqlite3"))
         file_name = "weird,file.c"
         src = os.path.join(path, "mock_src")
         dest = os.path.join(path, "modified_src")


### PR DESCRIPTION
Split the databases used by the test to avoid random failure