### PR TITLE
Python3.12

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -51,7 +51,7 @@ jobs:
       uses: ./support/actions/pytest
       with:
         tests: unittests
-        coverage: ${{ matrix.python-version == 3.8 }}
+        coverage: ${{ matrix.python-version == "3.12" }}
         cover-packages: ${{ env.ROOT_PKG }}
         coveralls-token: ${{ secrets.GITHUB_TOKEN }}
       env:
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.12"]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -51,7 +51,7 @@ jobs:
       uses: ./support/actions/pytest
       with:
         tests: unittests
-        coverage: ${{ matrix.python-version == "3.12" }}
+        coverage: ${{ matrix.python-version == 3.12 }}
         cover-packages: ${{ env.ROOT_PKG }}
         coveralls-token: ${{ secrets.GITHUB_TOKEN }}
       env:
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: [3.12]
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,7 +51,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.8', None),
+    'python': ('https://docs.python.org/3.12', None),
     'numpy': ("https://numpy.org/doc/stable/", None),
 }
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,11 +30,11 @@ classifiers=
         Operating System :: Microsoft :: Windows
         Operating System :: MacOS
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.7
         Programming Language :: Python :: 3.8
         Programming Language :: Python :: 3.9
         Programming Language :: Python :: 3.10
         Programming Language :: Python :: 3.11
+        Programming Language :: Python :: 3.12
 maintainer = SpiNNakerTeam
 maintainer_email = spinnakerusers@googlegroups.com
 keywords =

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ keywords =
         utilities
 
 [options]
-python_requires = >=3.7, <4
+python_requires = >=3.8, <4
 packages = find_namespace:
 zip_safe = True
 include_package_data = True

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import distutils.dir_util
 from setuptools import setup
+import shutil
 import os
 import sys
 
@@ -26,8 +26,8 @@ if __name__ == '__main__':
         this_dir = os.path.dirname(os.path.abspath(__file__))
         build_dir = os.path.join(this_dir, "build")
         if os.path.isdir(build_dir):
-            distutils.dir_util.remove_tree(build_dir)
+            shutil.rmtree(build_dir)
         egg_dir = os.path.join(this_dir, "SpiNNUtilities.egg-info")
         if os.path.isdir(egg_dir):
-            distutils.dir_util.remove_tree(egg_dir)
+            shutil.rmtree(egg_dir)
     setup()

--- a/spinn_utilities/ranged/abstract_sized.py
+++ b/spinn_utilities/ranged/abstract_sized.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Sized
 import itertools
 import logging
 import sys
-from typing import Any, Optional, Sequence, Sized, SupportsInt, Tuple, Union
+from typing import Any, Optional, Sequence, SupportsInt, Tuple, Union
 from typing_extensions import TypeAlias, TypeGuard
 import numpy
 

--- a/spinn_utilities/ranged/ranged_list.py
+++ b/spinn_utilities/ranged/ranged_list.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
+from collections.abc import Sized
 from typing import (
     Any, Callable, Generic, List, Iterable, Iterator, Optional, Sequence,
-    Sized, Tuple, Union, cast, final)
+    Tuple, Union, cast, final)
 from typing_extensions import TypeAlias, TypeGuard
 from spinn_utilities.overrides import overrides
 from spinn_utilities.helpful_functions import is_singleton


### PR DESCRIPTION
This set of PR does a few changes.

1 Remove stuff supporting  python 3.7
 - python_requires = >=3.8, <4
 - Programming Language :: Python :: 3.7 removed
 - dependency caps for 3.7 removed
 
2. removed [distutils](https://docs.python.org/3.11/library/distutils.html#module-distutils)
- replaced with shutil and packagin-g

3. replaced typing Sized with collection.abc.Sized

4. Tests python 2.12
- Programming Language :: Python ::3.12

5.  Changes test only done against one python to 3.12

6. Changed docs to link to 3.12

Related PR to be done in order
https://github.com/SpiNNakerManchester/SpiNNMachine/pull/234
https://github.com/SpiNNakerManchester/SpiNNMan/pull/387
https://github.com/SpiNNakerManchester/PACMAN/pull/538
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1151
https://github.com/SpiNNakerManchester/TestBase/pull/51
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1429
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/269
https://github.com/SpiNNakerManchester/SpiNNGym/pull/85
https://github.com/SpiNNakerManchester/Visualiser/pull/28
https://github.com/SpiNNakerManchester/SpiNNaker_PDP2/pull/83
https://github.com/SpiNNakerManchester/microcircuit_model (went to master)
https://github.com/SpiNNakerManchester/MarkovChainMonteCarlo/pull/59
https://github.com/SpiNNakerManchester/PyNN8Examples/pull/111
https://github.com/SpiNNakerManchester/IntroLab/pull/51
https://github.com/SpiNNakerManchester/spalloc/pull/93
https://github.com/SpiNNakerManchester/sPyNNakerVisualisers/pull/42
https://github.com/SpiNNakerManchester/sPyNNaker8NewModelTemplate/pull/109

Tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/254

These PRs require branch protection changes!

