### PR TITLE
overides type check should allow methods to return None (or not)

### DIFF
--- a/spinn_utilities/overrides.py
+++ b/spinn_utilities/overrides.py
@@ -123,16 +123,24 @@ class overrides(object):
                 raise AttributeError(
                     f"Super Method {self._superclass_method.__name__} "
                     f"has no arguments so should declare a return type")
-        if "return" in super_types:
-            if "return" not in method_types:
+            if "return" not in method_types and \
+                    not method_args.varkw and not method_args.varargs:
                 raise AttributeError(
                     f"Method {self._superclass_method.__name__} "
-                    f"has no return type, while super does")
+                    f"has no arguments so should declare a return type")
+
+        if "return" in super_types:
+            if "return" not in method_types:
+                if super_types["return"] is not None:
+                    raise AttributeError(
+                        f"Method {self._superclass_method.__name__} "
+                        f"has no return type, while super does")
         else:
             if "return" in method_types and not self._adds_typing:
-                raise AttributeError(
-                    f"Super Method {self._superclass_method.__name__} "
-                    f"has no return type, while this does")
+                if method_types["return"] is not None:
+                    raise AttributeError(
+                        f"Super Method {self._superclass_method.__name__} "
+                        f"has no return type, while this does")
 
     def __verify_method_arguments(self, method: Method):
         """

--- a/unittests/test_overrides.py
+++ b/unittests/test_overrides.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import pytest
-from typing import Any, List, Tuple
+from typing import Any, List
 from spinn_utilities.abstract_base import abstractmethod
 from spinn_utilities.overrides import overrides
 
 WRONG_ARGS = "Method has {} arguments but super class method has 4 arguments"
 BAD_DEFS = "Default arguments don't match super class method"
+
+overrides.check_types()
 
 
 class Base(object):
@@ -321,6 +323,8 @@ def test_add_return():
             @overrides(Base.bad)
             def bad(self, x: int, y: int, z: int) -> List[int]:
                 return super().foo(z, y, x)
+    assert str(e.value) == "Super Method bad has no return type, " \
+                           "while this does"
 
 
 def test_dont_add_return():
@@ -340,6 +344,8 @@ def test_missing_return_type():
             @overrides(Base.boo)
             def boo(self):
                 return 2
+    assert str(e.value) == "Method boo has no arguments " \
+                           "so should declare a return type"
 
 
 def test_with_missing_return():
@@ -369,4 +375,6 @@ def test_no_param_missing_return():
             @overrides(Base.no_param_no_return)
             def no_param_no_return(self):
                 pass
+    assert str(e.value) == "Super Method no_param_no_return has " \
+                           "no arguments so should declare a return type"
 

--- a/unittests/test_overrides.py
+++ b/unittests/test_overrides.py
@@ -377,4 +377,3 @@ def test_no_param_missing_return():
                 pass
     assert str(e.value) == "Super Method no_param_no_return has " \
                            "no arguments so should declare a return type"
-


### PR DESCRIPTION
In mypy declaring a None return is Optional.
An exception is that if there are no prams a None declaration is needed to trigger type checking

We had choose the style of not declaring the None return

Previously the overrides check had forced both overrider and overwriten to either both or neither to declare the None return

This pr allows one to declare a None return and the other not to.
