### PR TITLE
Less reports and data

### DIFF
--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from configparser import NoOptionError
 import logging
 import os
-from typing import Any, Callable, Collection, Dict, List, Optional, Set, Union
+from typing import Callable, Collection, Dict, List, Optional, Set, Union
 import spinn_utilities.conf_loader as conf_loader
 from spinn_utilities.configs import CamelCaseConfigParser
 from spinn_utilities.exceptions import ConfigException
@@ -329,6 +329,7 @@ def config_options(section: str) -> List[str]:
     if __config is None:
         raise ConfigException("configuration not loaded")
     return __config.options(section)
+
 
 # Typiying method more exactly fails
 # Union[Callable[[str, str], Any],

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -330,11 +330,11 @@ def config_options(section: str) -> List[str]:
         raise ConfigException("configuration not loaded")
     return __config.options(section)
 
-
+# Typiying method more exactly fails
+# Union[Callable[[str, str], Any],
+# Callable[[str, str, Optional[List[str]]], Any]]
 def _check_lines(py_path: str, line: str, lines: List[str], index: int,
-                 method: Union[Callable[[str, str], Any],
-                 Callable[[str, str, Optional[str]], Any]],
-                 used_cfgs: Dict[str, Set[str]], start,
+                 method: Callable, used_cfgs: Dict[str, Set[str]], start,
                  special_nones: Optional[List[str]] = None):
     """
     Support for `_check_python_file`. Gets section and option name.

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -331,7 +331,7 @@ def config_options(section: str) -> List[str]:
     return __config.options(section)
 
 
-# Typiying method more exactly fails
+# Tried to give method a more exact type but expects method to handle both!
 # Union[Callable[[str, str], Any],
 # Callable[[str, str, Optional[List[str]]], Any]]
 def _check_lines(py_path: str, line: str, lines: List[str], index: int,

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -332,7 +332,8 @@ def config_options(section: str) -> List[str]:
 
 
 def _check_lines(py_path: str, line: str, lines: List[str], index: int,
-                 method: Callable[[str, str], Any],
+                 method: Union[Callable[[str, str], Any],
+                 Callable[[str, str, Optional[str]], Any]],
                  used_cfgs: Dict[str, Set[str]], start,
                  special_nones: Optional[List[str]] = None):
     """

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -269,20 +269,23 @@ def get_config_bool(section: str, option: str) -> bool:
     return value
 
 
-def get_config_bool_or_none(section, option) -> Optional[bool]:
+def get_config_bool_or_none(section, option,
+                            special_nones: Optional[List[str]] = None
+                            ) -> Optional[bool]:
     """
     Get the Boolean value of a configuration option.
 
     :param str section: What section to get the option from.
     :param str option: What option to read.
+    :param special_nones: What special values to except as None
     :return: The option value.
     :rtype: bool
     :raises ConfigException: if the Value would be None
     """
     if __config is None:
-        return _pre_load_config().get_bool(section, option)
+        return _pre_load_config().get_bool(section, option, special_nones)
     else:
-        return __config.get_bool(section, option)
+        return __config.get_bool(section, option, special_nones)
 
 
 def set_config(section: str, option: str, value: Optional[str]):
@@ -330,7 +333,8 @@ def config_options(section: str) -> List[str]:
 
 def _check_lines(py_path: str, line: str, lines: List[str], index: int,
                  method: Callable[[str, str], Any],
-                 used_cfgs: Dict[str, Set[str]], start):
+                 used_cfgs: Dict[str, Set[str]], start,
+                 special_nones: Optional[List[str]] = None):
     """
     Support for `_check_python_file`. Gets section and option name.
 
@@ -340,6 +344,7 @@ def _check_lines(py_path: str, line: str, lines: List[str], index: int,
     :param method: Method to call to check cfg
     :param dict(str), set(str) used_cfgs:
         Dict of used cfg options to be added to
+    :param special_nones: What special values to except as None
     :raises ConfigException: If an unexpected or uncovered `get_config` found
     """
     while ")" not in line:
@@ -363,7 +368,10 @@ def _check_lines(py_path: str, line: str, lines: List[str], index: int,
             print(line)
             return
         try:
-            method(section, option)
+            if special_nones:
+                method(section, option, special_nones)
+            else:
+                method(section, option)
         except Exception as original:
             raise ConfigException(
                 f"failed in line:{index} of file: {py_path} with "
@@ -371,12 +379,14 @@ def _check_lines(py_path: str, line: str, lines: List[str], index: int,
         used_cfgs[section].add(option)
 
 
-def _check_python_file(py_path: str, used_cfgs: Dict[str, Set[str]]):
+def _check_python_file(py_path: str, used_cfgs: Dict[str, Set[str]],
+                       special_nones: Optional[List[str]] = None):
     """
     A testing function to check that all the `get_config` calls work.
 
     :param str py_path: path to file to be checked
     :param used_cfgs: dict of cfg options found
+    :param special_nones: What special values to except as None
     :raises ConfigException: If an unexpected or uncovered `get_config` found
     """
     with open(py_path, 'r', encoding="utf-8") as py_file:
@@ -384,7 +394,8 @@ def _check_python_file(py_path: str, used_cfgs: Dict[str, Set[str]]):
         for index, line in enumerate(lines):
             if ("skip_if_cfg" in line):
                 _check_lines(py_path, line, lines, index,
-                             get_config_bool_or_none, used_cfgs, "skip_if_cfg")
+                             get_config_bool_or_none, used_cfgs, "skip_if_cfg",
+                             special_nones)
             if ("configuration.get" in line):
                 _check_lines(py_path, line, lines, index,
                              get_config_bool_or_none, used_cfgs,
@@ -394,7 +405,8 @@ def _check_python_file(py_path: str, used_cfgs: Dict[str, Set[str]]):
             if (("get_config_bool(" in line) or
                     ("get_config_bool_or_none(" in line)):
                 _check_lines(py_path, line, lines, index,
-                             get_config_bool_or_none, used_cfgs, "get_config")
+                             get_config_bool_or_none, used_cfgs,
+                             "get_config_bool", special_nones)
             if (("get_config_float(" in line) or
                     ("get_config_float_or_none(" in line)):
                 _check_lines(py_path, line, lines, index,
@@ -489,7 +501,8 @@ def _check_cfgs(path: str):
 def run_config_checks(directories: Union[str, Collection[str]], *,
                       exceptions: Union[str, Collection[str]] = (),
                       repeaters: Optional[Collection[str]] = (),
-                      check_all_used: bool = True):
+                      check_all_used: bool = True,
+                      special_nones: Optional[List[str]] = None):
     """
     Master test.
 
@@ -503,6 +516,7 @@ def run_config_checks(directories: Union[str, Collection[str]], *,
     :param exceptions:
     :param repeaters:
     :param bool check_all_used: Toggle for the used test.
+    :param special_nones: What special values to except as None
     :raises ConfigException: If an incorrect directory passed in
     """
     if isinstance(directories, str):
@@ -534,7 +548,7 @@ def run_config_checks(directories: Union[str, Collection[str]], *,
                     _check_cfg_file(config1, cfg_path)
                 elif file_name.endswith(".py"):
                     py_path = os.path.join(root, file_name)
-                    _check_python_file(py_path, used_cfgs)
+                    _check_python_file(py_path, used_cfgs, special_nones)
 
     if not check_all_used:
         return

--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -115,12 +115,14 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
             return None
         return float(value)
 
-    def get_bool(self, section: str, option: str) -> Optional[bool]:
+    def get_bool(self, section: str, option: str,
+                 special_nones: Optional[List[str]]) -> Optional[bool]:
         """
         Get the Boolean value of an option.
 
         :param str section: What section to get the option from.
         :param str option: What option to read.
+        :param special_nones: What special values to except as None
         :return: The option value.
         :rtype: bool
         """
@@ -131,5 +133,7 @@ class CamelCaseConfigParser(configparser.RawConfigParser):
         if lower in FALSES:
             return False
         if lower in NONES:
+            return None
+        if special_nones and lower in special_nones:
             return None
         raise ValueError(f"invalid truth value {value}")


### PR DESCRIPTION
needed for https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1213

Until changed by ConfigHandler many cfg setting which will be a boolean default to Info or debug

This pr allow passing in special_nones via the cfg checker.

---

changing NONES to include these does not work as then "[Mode]mode=Info2 would be considered None 