### PR TITLE
data_specification_loaded to turn off requires data spec / reset

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -536,8 +536,7 @@ class UtilsDataView(object):
         Set to True at the start and by any change that could require
         data generation or mapping
         Remains True during the first run after a data change
-        Only set to False at the *end* of the first run
-
+        Only set to False after the data is loaded.
         """
         return cls.__data._requires_data_generation
 
@@ -546,7 +545,7 @@ class UtilsDataView(object):
         """
         Sets `requires_data_generation` to True.
 
-        Only the end of a run can set it to False
+        Set to False after data is loaded
         """
         cls.check_user_can_act()
         cls.__data._requires_data_generation = True
@@ -588,7 +587,6 @@ class UtilsDataView(object):
         """
         cls.__data._run_status = RunStatus.NOT_RUNNING
         cls.__data._reset_status = ResetStatus.HAS_RUN
-        cls.__data._requires_data_generation = False
         cls.__data._requires_mapping = False
 
     @classmethod

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -146,7 +146,6 @@ class UtilsDataWriter(UtilsDataView):
                 f"{self.__data._run_status}")
         self.__data._run_status = RunStatus.NOT_RUNNING
         self.__data._reset_status = ResetStatus.HAS_RUN
-        #self.__data._requires_data_generation = False
         self.__data._requires_mapping = False
 
     def _hard_reset(self) -> None:
@@ -212,6 +211,14 @@ class UtilsDataWriter(UtilsDataView):
         Causes get_requires_data_generation to report False
         """
         self.__data._requires_data_generation = False
+
+    def set_requires_data_generation(self) -> None:
+        """
+        Sets `requires_data_generation` to True.
+
+        Set to False after data is loaded
+        """
+        self.__data._requires_data_generation = True
 
     def request_stop(self) -> None:
         """

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -212,7 +212,8 @@ class UtilsDataWriter(UtilsDataView):
         """
         self.__data._requires_data_generation = False
 
-    def set_requires_data_generation(self) -> None:
+    def set_requires_data_generation(
+            self) -> None:  # pylint: disable=arguments-differ
         """
         Sets `requires_data_generation` to True.
 

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -212,14 +212,14 @@ class UtilsDataWriter(UtilsDataView):
         """
         self.__data._requires_data_generation = False
 
-    def set_requires_data_generation(   # pylint: disable=arguments-differ
-            self) -> None:
+    @classmethod
+    def set_requires_data_generation(cls) -> None:
         """
         Sets `requires_data_generation` to True.
 
         Set to False after data is loaded
         """
-        self.__data._requires_data_generation = True
+        cls.__data._requires_data_generation = True
 
     def request_stop(self) -> None:
         """

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -212,8 +212,8 @@ class UtilsDataWriter(UtilsDataView):
         """
         self.__data._requires_data_generation = False
 
-    def set_requires_data_generation(
-            self) -> None:  # pylint: disable=arguments-differ
+    def set_requires_data_generation(   # pylint: disable=arguments-differ
+            self) -> None:
         """
         Sets `requires_data_generation` to True.
 

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -146,7 +146,7 @@ class UtilsDataWriter(UtilsDataView):
                 f"{self.__data._run_status}")
         self.__data._run_status = RunStatus.NOT_RUNNING
         self.__data._reset_status = ResetStatus.HAS_RUN
-        self.__data._requires_data_generation = False
+        #self.__data._requires_data_generation = False
         self.__data._requires_mapping = False
 
     def _hard_reset(self) -> None:
@@ -204,6 +204,14 @@ class UtilsDataWriter(UtilsDataView):
         raise UnexpectedStateChange(
             f"Unexpected call to reset while reset status is "
             f"{self.__data._reset_status}")
+
+    def data_specification_loaded(self) -> None:
+        """
+        Used to indicate that load data specification has run/
+    .
+        Causes get_requires_data_generation to report False
+        """
+        self.__data._requires_data_generation = False
 
     def request_stop(self) -> None:
         """

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1033,6 +1033,8 @@ class TestUtilsData(unittest.TestCase):
             writer.set_requires_data_generation()
         with self.assertRaises(SimulatorRunningException):
             writer.set_requires_mapping()
+        writer.data_specification_loaded()
+        self.assertFalse(writer.get_requires_data_generation())
         writer.finish_run()
 
         # False after run

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1030,15 +1030,20 @@ class TestUtilsData(unittest.TestCase):
         self.assertTrue(writer.get_requires_mapping())
         # Can not be changed during run
         with self.assertRaises(SimulatorRunningException):
-            writer.set_requires_data_generation()
+            UtilsDataView.set_requires_data_generation()
         with self.assertRaises(SimulatorRunningException):
             writer.set_requires_mapping()
         writer.data_specification_loaded()
         self.assertFalse(writer.get_requires_data_generation())
+        with self.assertRaises(SimulatorRunningException):
+            UtilsDataView.set_requires_data_generation()
+        writer.set_requires_data_generation()
+        self.assertTrue(writer.get_requires_data_generation())
         writer.finish_run()
 
+        # Stay as it was
+        self.assertTrue(writer.get_requires_data_generation())
         # False after run
-        self.assertFalse(writer.get_requires_data_generation())
         self.assertFalse(writer.get_requires_mapping())
 
         # Setting requires mapping sets both to True


### PR DESCRIPTION
This pr changes how requires_data_generation is used.

Master
---
Things that turn requires_data_generation on:
- setup
- hard reset
- View.set_requires_data_generation()
-- Called by vertex if synapse_dynamics.changes_during_run
- View.set_requires_mapping
-- called by anything that adds to the graph

Things that turned requires_data_generation 
- Finish_run

CHANGE
---
data_specification_loaded to turn requires_data_generation  off
writer.set_requires_data_generation()  (which can be called during run)

USAGE
--
If we allow timed runs to be stopped this allows requires_data_generation to be turned on in a way that is kept when Finish_run is called.

REQIORES
---
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1227
- requires checking get_requires_data_generation if in a second non reset run
- calling data_specification_loaded  after loading / reloading



