### PR TITLE
Move all report paths to cfg

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -52,6 +52,7 @@ class _UtilsDataModel(object):
         "_requires_mapping",
         "_reset_status",
         "_run_dir_path",
+        "_run_number",
         "_run_status",
         "_temporary_directory",
     ]
@@ -74,6 +75,7 @@ class _UtilsDataModel(object):
         """
         Clears out all data.
         """
+        self._run_number: Optional[int] = None
         self._report_dir_path: Optional[str] = None
         self._hard_reset()
 
@@ -471,6 +473,23 @@ class UtilsDataView(object):
         if cls._is_mocked():
             return cls._temporary_dir_path()
         raise cls._exception("run_dir_path")
+
+    #  run number
+
+    @classmethod
+    def get_run_number(cls) -> int:
+        """
+        Get the number of this or the next run.
+
+        Run numbers start at 1
+
+        :rtype: int
+        :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
+            If the run_number is currently unavailable
+        """
+        if cls.__data._run_number is None:
+            raise cls._exception("run_number")
+        return cls.__data._run_number
 
     @classmethod
     def get_executable_finder(cls) -> ExecutableFinder:

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -112,6 +112,8 @@ class UtilsDataWriter(UtilsDataView):
         self.__data._clear()
         self.__data._data_status = DataStatus.MOCKED
         self.__data._reset_status = ResetStatus.NOT_SETUP
+        # run numbers start at 1 and when not running this is the next one
+        self.__data._run_number = 1
         self.__data._run_status = RunStatus.NOT_SETUP
 
     def _setup(self) -> None:
@@ -121,6 +123,8 @@ class UtilsDataWriter(UtilsDataView):
         self.__data._clear()
         self.__data._data_status = DataStatus.SETUP
         self.__data._reset_status = ResetStatus.SETUP
+        # run numbers start at 1 and when not running this is the next one
+        self.__data._run_number = 1
         self.__data._run_status = RunStatus.NOT_RUNNING
 
     def start_run(self) -> None:
@@ -144,6 +148,8 @@ class UtilsDataWriter(UtilsDataView):
             raise UnexpectedStateChange(
                 f"Unexpected finish run when in run state "
                 f"{self.__data._run_status}")
+        assert self.__data._run_number is not None
+        self.__data._run_number += 1
         self.__data._run_status = RunStatus.NOT_RUNNING
         self.__data._reset_status = ResetStatus.HAS_RUN
         self.__data._requires_data_generation = False

--- a/unittests/data/test_utils_data.py
+++ b/unittests/data/test_utils_data.py
@@ -1066,3 +1066,26 @@ class TestUtilsData(unittest.TestCase):
             UtilsDataView.raise_skiptest("Skip me")
         with self.assertRaises(unittest.SkipTest):
             UtilsDataView.raise_skiptest("Skip me", ValueError("nope"))
+
+    def test_run_number(self) -> None:
+        writer = UtilsDataWriter.setup()
+        self.assertEqual(1, UtilsDataView.get_run_number())
+        writer.start_run()
+        self.assertEqual(1, UtilsDataView.get_run_number())
+        writer.finish_run()
+        self.assertEqual(2, UtilsDataView.get_run_number())
+        # run_dir_path only changed on hard reset
+        writer.start_run()
+        self.assertEqual(2, UtilsDataView.get_run_number())
+        # run_dir_path only changed on hard reset
+        writer.finish_run()
+        self.assertEqual(3, UtilsDataView.get_run_number())
+        writer.soft_reset()
+        self.assertEqual(3, UtilsDataView.get_run_number())
+        # run_dir_path only changed on hard reset
+        writer.hard_reset()
+        self.assertEqual(3, UtilsDataView.get_run_number())
+        writer.start_run()
+        self.assertEqual(3, UtilsDataView.get_run_number())
+        writer.finish_run()
+        self.assertEqual(4, UtilsDataView.get_run_number())

--- a/unittests/test_configs.py
+++ b/unittests/test_configs.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from testfixtures import LogCapture
+
 from spinn_utilities.config_setup import unittest_setup
 from spinn_utilities.config_holder import (
+    _check_section_exists, 
     get_config_bool, get_config_bool_or_none, get_config_float,
     get_config_float_or_none, get_config_int, get_config_int_or_none,
+    get_report_path,
     get_config_str, get_config_str_or_none,  set_config)
 from spinn_utilities.exceptions import ConfigException, SpiNNUtilsException
+from spinn_utilities.testing import log_checker
 
 
 def test_configs_None() -> None:
@@ -49,3 +54,22 @@ def test_configs_None() -> None:
         raise SpiNNUtilsException("Expected ConfigException")
     except ConfigException:
         pass
+
+def test_get_report_path():
+    unittest_setup()
+    _check_section_exists("Reports")
+    set_config("Reports", "foo", "foo.txt")
+    path = get_report_path("foo")
+    assert path.endswith("foo.txt")
+
+    with LogCapture() as lc:
+        path = get_report_path("foo", n_run=2)
+        log_checker.assert_logs_warning_contains(
+            lc.records, "does not have a (n_run)")
+        assert path.endswith("foo.txt")
+
+    set_config("Reports", "foo_run", "foo(n_run).txt")
+    path = get_report_path("foo_run")
+    assert path.endswith("foo1.txt")
+    path = get_report_path("foo_run", n_run=2)
+    assert path.endswith("foo2.txt")


### PR DESCRIPTION
needed for https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1274

- run_number data moved to Utils level
- get_report_path function which given a cfg option name returns the path specified
- added _check_section_exists method to allow (ONLY) tests to create a confiog section if needed

get_report_path could in later pr be extended to support thinks like
-ebrains directory
