### PR TITLE
use type any so override types in super

### DIFF
--- a/unittests/test_log.py
+++ b/unittests/test_log.py
@@ -140,10 +140,10 @@ class MockConfig1(CamelCaseConfigParser):
     def get(self, section: str, option: str) -> str:  # type: ignore[override]
         return "debug"
 
-    def has_section(self, section: str) -> bool:
+    def has_section(self, section: Any) -> bool:
         return False
 
-    def has_option(self, section: str, option: str) -> bool:
+    def has_option(self, section: Any, option: Any) -> bool:
         return False
 
 
@@ -157,10 +157,10 @@ class MockConfig2(CamelCaseConfigParser):
     def get(self, section: str, option: str) -> str:  # type: ignore[override]
         return "critical"
 
-    def has_section(self, section: str) -> bool:
+    def has_section(self, section: Any) -> bool:
         return True
 
-    def has_option(self, section: str, option: str) -> bool:
+    def has_option(self, section: Any, option: Any) -> bool:
         return option == 'warning'
 
 


### PR DESCRIPTION
fixes new overrides check found in mastet

Subclass params can be broader so just use Any


Note; Did not fix get as that is much more complicated:
See: https://github.com/SpiNNakerManchester/SpiNNUtils/actions/runs/15384822717/job/43281381078


