### PR TITLE
Improve doc type tester

### DIFF
--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -326,7 +326,7 @@ def has_config_option(section: str, option: str) -> bool:
     :return: True if and only if the option is defined. It may be `None`
     """
     if __config is None:
-        raise ConfigException("configuration not loaded")
+        return False
     else:
         return __config.has_option(section, option)
 

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -336,7 +336,7 @@ def has_config_option(section: str, option: str) -> bool:
     :return: True if and only if the option is defined. It may be `None`
     """
     if __config is None:
-        return False
+        raise ConfigException("configuration not loaded")
     else:
         return __config.has_option(section, option)
 

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -88,7 +88,7 @@ class DocsChecker(object):
         try:
             ast_tree = ast.parse(raw_tree, type_comments=True)
         except SyntaxError as ex:
-            raise SyntaxError(f"{ex.msg} of {file_path}")
+            raise SyntaxError(f"{ex.msg} of {file_path}") from ex
         for node in ast.walk(ast_tree):
             if isinstance(node, ast.FunctionDef):
                 self.check_function(node)

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -132,7 +132,7 @@ class DocsChecker(object):
                         index = key_index
             if index < sys.maxsize:
                 while index > 1 and docs[index-1] in [" ", "\t"]:
-                    index-= 1
+                    index -= 1
                 if index >= 2:
                     if docs[index-2: index] != "\n\n":
                         error += "Missing blank line after description"

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -108,7 +108,7 @@ class DocsChecker(object):
         for param in docstring.params:
             if param.arg_name not in param_names:
                 error += f"{param.arg_name}: is incorrect "
-            elif param.type_name is not None:
+            elif param.type_name:
                 error += f"{param.arg_name}: is typed "
             elif not param.description:
                 if self.__check_params:

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -124,6 +124,9 @@ class DocsChecker(object):
                     error += "No short description provided."
 
         if docs is not None:
+            for key in [":type", ":rtype"]:
+                if key in docs:
+                    error += f"found {key} "
             index = sys.maxsize
             for key in [":param", ":return", ":raises"]:
                 if key in docs:

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -85,7 +85,10 @@ class DocsChecker(object):
         self.__file_path = file_path
         with open(file_path, "r", encoding="utf-8") as file:
             raw_tree = file.read()
-        ast_tree = ast.parse(raw_tree, type_comments=True)
+        try:
+            ast_tree = ast.parse(raw_tree, type_comments=True)
+        except SyntaxError as ex:
+            raise SyntaxError(f"{ex.msg} of {file_path}")
         for node in ast.walk(ast_tree):
             if isinstance(node, ast.FunctionDef):
                 self.check_function(node)


### PR DESCRIPTION
Must be done after:
https://github.com/SpiNNakerManchester/SpiNNMachine/pull/292
https://github.com/SpiNNakerManchester/SpiNNMan/pull/445
(it finds the rtype those remove)

- check for :type and :rtype
- Ignore type empty str (spalloc style docs)

includes https://github.com/SpiNNakerManchester/SpiNNUtils/pull/318