### PR TITLE
Returns docs

### DIFF
--- a/spinn_utilities/abstract_base.py
+++ b/spinn_utilities/abstract_base.py
@@ -35,6 +35,8 @@ def abstractmethod(funcobj: T) -> T:
             @abstractmethod
             def my_abstract_method(self, ...):
                 ...
+
+    :returns: method being wrapped
     """
     funcobj.__isabstractmethod__ = True  # type: ignore[attr-defined]
     return funcobj

--- a/spinn_utilities/citation/citation_aggregator.py
+++ b/spinn_utilities/citation/citation_aggregator.py
@@ -174,6 +174,8 @@ class CitationAggregator(object):
     def locate_path_for_c_dependency(true_software_name: str) -> Optional[str]:
         """
         Tries to find the software in the environment PATH (s)
+
+        :returns: Path to the software if found
         """
         environment_path_variable = os.environ.get('PATH')
         if environment_path_variable is not None:

--- a/spinn_utilities/classproperty.py
+++ b/spinn_utilities/classproperty.py
@@ -21,6 +21,10 @@ class _ClassPropertyDescriptor(object):
     """
 
     def __init__(self, fget: Callable) -> None:
+        """
+        :param fget: function to be wrapped
+        :param fget:
+        """
         self.fget = fget
 
     def __get__(
@@ -42,6 +46,8 @@ def classproperty(func: Callable) -> _ClassPropertyDescriptor:
             @classproperty
             def my_property(cls):
                 return cls._my_property
+
+    :returns: An object describing the property.
     """
     if not isinstance(func, (classmethod, staticmethod)):
         # mypy claims expression has type "classmethod ...

--- a/spinn_utilities/classproperty.py
+++ b/spinn_utilities/classproperty.py
@@ -20,18 +20,17 @@ class _ClassPropertyDescriptor(object):
     A class to handle the management of class properties.
     """
 
-    def __init__(self, fget: Callable) -> None:
+    def __init__(self, method: Callable) -> None:
         """
-        :param fget: function to be wrapped
-        :param fget:
+        :param method: Function being wrapped
         """
-        self.fget = fget
+        self.method = method
 
     def __get__(
             self, obj: Optional[Any], klass: Optional[Type] = None) -> Any:
         if klass is None:
             klass = type(obj)
-        return self.fget.__get__(obj, klass)()
+        return self.method.__get__(obj, klass)()
 
 
 def classproperty(func: Callable) -> _ClassPropertyDescriptor:

--- a/spinn_utilities/conf_loader.py
+++ b/spinn_utilities/conf_loader.py
@@ -50,6 +50,7 @@ def install_cfg_and_error(
     :param config_locations:
         List of paths where the user configuration files
         were looked for. Only used for the message
+    :return: Exception to be raised by caller
     :raise spinn_utilities.configs.NoConfigFoundException:
         Always raised
     """

--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -46,9 +46,11 @@ def add_default_cfg(default: str) -> None:
 
 def get_default_cfgs() -> Tuple[str, ...]:
     """
-    Returns the default configuration files as a tuple.
+    The default configuration files
 
     This is a read only values to be used outside of normal operations
+
+    :returns: The default configuration files as a tuple.
     """
     return tuple(__default_config_files)
 
@@ -124,6 +126,7 @@ def load_config() -> CamelCaseConfigParser:
     Reads in all the configuration files, resetting all values.
 
     :raises ConfigException: If called before setting defaults
+    :returns: A fully loaded parser object
     """
     global __config
     if not __default_config_files:
@@ -309,8 +312,7 @@ def set_config(section: str, option: str, value: Optional[str]) -> None:
 
 def config_sections() -> List[str]:
     """
-    Return a list of section names
-
+    :returns: A list of section names
     """
     if __config is None:
         raise ConfigException("configuration not loaded")
@@ -319,7 +321,7 @@ def config_sections() -> List[str]:
 
 def configs_loaded() -> bool:
     """
-    True if and only if the configuration was loaded
+    :returns: True if and only if the configuration was loaded
     """
     if __config is None:
         return False
@@ -343,9 +345,8 @@ def has_config_option(section: str, option: str) -> bool:
 
 def config_options(section: str) -> List[str]:
     """
-    Return a list of option names for the given section name.
-
     :param section: What section to list options for.
+    :returns: a list of option names for the given section name.
     """
     if __config is None:
         raise ConfigException("configuration not loaded")

--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -35,6 +35,8 @@ def optionxform(optionstr: str) -> str:
     """
     Transforms the name of an option to lower case and strips
     underscores, so matching is more user-friendly.
+
+    :returns: optionstr in all lower case with underscores removed
     """
     lower = optionstr.lower()
     return lower.replace("_", "")
@@ -67,6 +69,8 @@ class TypedConfigParser(configparser.RawConfigParser):
              encoding: Optional[str] = None) -> List[str]:
         """
         Read and parse a filename or a list of filenames.
+
+        :returns: list of successfully read files.
         """
         new_files = super().read(filenames, encoding)
         self._read_files.extend(new_files)
@@ -169,5 +173,8 @@ class CamelCaseConfigParser(TypedConfigParser):
         """
         Transforms the name of an option to lower case and strips
         underscores, so matching is more user-friendly.
+
+        :param optionstr: What option label to transform.
+        :returns: optionstr in all lower case with underscores removed
         """
         return optionxform(optionstr)

--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -31,14 +31,14 @@ else:
     _Path = str
 
 
-def optionxform(option: str) -> str:
+def optionxform(optionstr: str) -> str:
     """
     Transforms the name of an option to lower case and strips
     underscores, so matching is more user-friendly.
 
-    :returns: option in all lower case with underscores removed
+    :returns: optionstr in all lower case with underscores removed
     """
-    lower = option.lower()
+    lower = optionstr.lower()
     return lower.replace("_", "")
 
 
@@ -55,7 +55,7 @@ class TypedConfigParser(configparser.RawConfigParser):
         super().__init__()
         self._read_files: List[str] = list()
 
-    def optionxform(self, option: str) -> str:
+    def optionxform(self, optionstr: str) -> str:
         """
         Override so that option names are NOT case corrected.
 
@@ -63,7 +63,7 @@ class TypedConfigParser(configparser.RawConfigParser):
 
         :return: option string exactly as is
         """
-        return option
+        return optionstr
 
     def read(self, filenames: _Path,
              encoding: Optional[str] = None) -> List[str]:
@@ -169,12 +169,12 @@ class CamelCaseConfigParser(TypedConfigParser):
     """
     __slots__ = []
 
-    def optionxform(self, option: str) -> str:
+    def optionxform(self, optionstr: str) -> str:
         """
         Transforms the name of an option to lower case and strips
         underscores, so matching is more user-friendly.
 
-        :param option: What option label to transform.
-        :returns: option in all lower case with underscores removed
+        :param optionstr: What option label to transform.
+        :returns: optionstr in all lower case with underscores removed
         """
-        return optionxform(option)
+        return optionxform(optionstr)

--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -31,14 +31,14 @@ else:
     _Path = str
 
 
-def optionxform(optionstr: str) -> str:
+def optionxform(option: str) -> str:
     """
     Transforms the name of an option to lower case and strips
     underscores, so matching is more user-friendly.
 
-    :returns: optionstr in all lower case with underscores removed
+    :returns: option in all lower case with underscores removed
     """
-    lower = optionstr.lower()
+    lower = option.lower()
     return lower.replace("_", "")
 
 
@@ -55,7 +55,7 @@ class TypedConfigParser(configparser.RawConfigParser):
         super().__init__()
         self._read_files: List[str] = list()
 
-    def optionxform(self, optionstr: str) -> str:
+    def optionxform(self, option: str) -> str:
         """
         Override so that option names are NOT case corrected.
 
@@ -63,7 +63,7 @@ class TypedConfigParser(configparser.RawConfigParser):
 
         :return: option string exactly as is
         """
-        return optionstr
+        return option
 
     def read(self, filenames: _Path,
              encoding: Optional[str] = None) -> List[str]:
@@ -169,12 +169,12 @@ class CamelCaseConfigParser(TypedConfigParser):
     """
     __slots__ = []
 
-    def optionxform(self, optionstr: str) -> str:
+    def optionxform(self, option: str) -> str:
         """
         Transforms the name of an option to lower case and strips
         underscores, so matching is more user-friendly.
 
-        :param optionstr: What option label to transform.
-        :returns: optionstr in all lower case with underscores removed
+        :param option: What option label to transform.
+        :returns: option in all lower case with underscores removed
         """
-        return optionxform(optionstr)
+        return optionxform(option)

--- a/spinn_utilities/configs/config_documentor.py
+++ b/spinn_utilities/configs/config_documentor.py
@@ -117,6 +117,8 @@ class _ConfigGroup(object):
         Gets a list of the cfg settings in the group that point to a path.
 
         Path cfg options are those which start with path_ or tpath_
+
+        :returns: The List of cfg values which point to a path
         """
         paths = []
         for option, value in self._cfg.items():
@@ -160,7 +162,7 @@ class _ConfigGroup(object):
 
     def missing_docs(self) -> bool:
         """
-        Returns True if this group does not have any docs
+        :returns: True if this group does not have any docs
         """
         return not self._docs
 

--- a/spinn_utilities/data/data_status.py
+++ b/spinn_utilities/data/data_status.py
@@ -49,5 +49,6 @@ class DataStatus(Enum):
         Returns an instance of the most suitable data-not-available exception.
 
         :param data: Parameter to pass to the relevant constructor.
+        :returns: The exception to be raise based on the current status.
          """
         return self._exception(data)

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -209,7 +209,7 @@ class UtilsDataView(object):
         .. warning::
             During the first run after reset this continues to return True!
 
-        Returns False after a reset that was considered soft.
+        :returns: True between a hard reset and the end of the next run.
         """
         return cls.__data._reset_status == ResetStatus.HARD_RESET
 
@@ -222,6 +222,9 @@ class UtilsDataView(object):
             During the first run after reset this continues to return True!
 
         Returns False after a reset that was considered hard.
+
+        :returns: True between a soft reset and either a hard reset
+            or the end of the next run.
         """
         return cls.__data._reset_status == ResetStatus.SOFT_RESET
 
@@ -230,6 +233,7 @@ class UtilsDataView(object):
         """
         Check if the simulation has run at least once, ignoring resets.
 
+        :returns: True if the simulation has ever run since setup
         :raises NotImplementedError:
             If this is called from an unexpected state
         """
@@ -250,6 +254,9 @@ class UtilsDataView(object):
 
         :raises NotImplementedError:
             If this is called from an unexpected state
+
+        :returns: True if and only if the simulation has run
+           but not been reset.
         """
         if cls.__data._reset_status == ResetStatus.HAS_RUN:
             return True
@@ -271,6 +278,7 @@ class UtilsDataView(object):
 
         It also returns False after a `sim.stop` or `sim.end` call starts
 
+        :returns: True if a reset was called since the last `sim.run`
         :raises NotImplementedError:
             If this is called from an unexpected state
         """
@@ -308,6 +316,7 @@ class UtilsDataView(object):
 
         Reset numbers start at zero
 
+        :returns: The reset number which may be 0
          :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the run_number is currently unavailable
         """
@@ -330,6 +339,7 @@ class UtilsDataView(object):
 
         Reset numbers start at zero
 
+        :returns: The reset number or an empty string if not reset
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the run_number is currently unavailable
         """
@@ -347,6 +357,7 @@ class UtilsDataView(object):
 
         :raises NotImplementedError:
             If this is called from an unexpected state
+        :returns: False unless a stop request has been sent.
         """
         if cls.__data._run_status == RunStatus.IN_RUN:
             return True
@@ -361,8 +372,12 @@ class UtilsDataView(object):
         """
         Checks if there is currently a simulation running.
 
+        This includes the not just the time code is running on Chip but also
+        all the pre- and post-stages such as mapping, loading and reading data
+
         That is a call to run has started but not yet stopped.
 
+        :returns: TRue if and only if the simulation is running
         """
         return cls.__data._run_status in [
             RunStatus.IN_RUN, RunStatus.STOP_REQUESTED]
@@ -420,6 +435,7 @@ class UtilsDataView(object):
 
         :raises NotImplementedError:
             If this is called from an unexpected state
+        :returns: True if setup has been called, False otherwise
         """
         if cls.__data._run_status in [RunStatus.NOT_SETUP, RunStatus.SHUTDOWN]:
             return False
@@ -441,6 +457,7 @@ class UtilsDataView(object):
 
         :raises NotImplementedError:
             If the data has not yet been set up or on an unexpected run_status
+        :returns: True if user's script may access data
         """
         if cls.__data._run_status in [
                 RunStatus.IN_RUN, RunStatus.STOPPING,
@@ -486,6 +503,8 @@ class UtilsDataView(object):
         Determines if simulator has already been shutdown.
 
         This returns False in the Mocked state
+
+        :returns: True if the simulation has been shutdown
         """
         return cls.__data._run_status == RunStatus.SHUTDOWN
 
@@ -516,6 +535,7 @@ class UtilsDataView(object):
             In unit test mode this returns a temporary directory
             shared by all path methods.
 
+        :returns: Path to last run directory created
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the run_dir_path is currently unavailable
         """
@@ -537,6 +557,7 @@ class UtilsDataView(object):
 
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the simulation_time_step is currently unavailable
+        :returns: The path to the directory that holds all the reports
         """
         if cls.__data._timestamp_dir_path is not None:
             return cls.__data._timestamp_dir_path
@@ -579,6 +600,7 @@ class UtilsDataView(object):
 
         Run numbers start at 1
 
+        :returns: The current run number
         :raises ~spinn_utilities.exceptions.SpiNNUtilsException:
             If the run_number is currently unavailable
         """
@@ -589,8 +611,7 @@ class UtilsDataView(object):
     @classmethod
     def get_executable_finder(cls) -> ExecutableFinder:
         """
-        The ExcutableFinder object created at time code is imported.
-
+        :returns: The ExcutableFinder object created at time code is imported.
         """
         return cls.__data._executable_finder
 
@@ -652,6 +673,7 @@ class UtilsDataView(object):
         Remains True during the first run after a data change
         Only set to False at the *end* of the first run
 
+        :returns: True if the data generation steps should be included
         """
         return cls.__data._requires_data_generation
 
@@ -674,6 +696,8 @@ class UtilsDataView(object):
         any mapping stage to be called
         Remains True during the first run after a requires mapping.
         Only set to False at the *end* of the first run
+
+        :returns: True if the mapping steps should be included
         """
         return cls.__data._requires_mapping
 

--- a/spinn_utilities/data/utils_data_writer.py
+++ b/spinn_utilities/data/utils_data_writer.py
@@ -272,7 +272,7 @@ class UtilsDataWriter(UtilsDataView):
 
     def get_report_dir_path(self) -> str:
         """
-        Returns path to existing reports directory.
+        Path to existing reports directory.
 
         This is the high level directory which in which `timestamp` directories
         and `run` directories are placed.
@@ -282,6 +282,8 @@ class UtilsDataWriter(UtilsDataView):
 
         :raises SpiNNUtilsException:
             If the `simulation_time_step` is currently unavailable
+        :returns: path to existing reports directory.
+
         """
         if self.__data._report_dir_path:
             return self.__data._report_dir_path

--- a/spinn_utilities/helpful_functions.py
+++ b/spinn_utilities/helpful_functions.py
@@ -33,6 +33,8 @@ def is_singleton(value: Any) -> TypeGuard[Union[bool, int, float]]:
 
     Strings are considered singleton as only rarely will someone use a string
     to represent an iterable of characters.
+
+    :returns: True if the value is a singleton, False otherwise.
     """
     return not hasattr(value, '__iter__') or isinstance(value, str)
 

--- a/spinn_utilities/log.py
+++ b/spinn_utilities/log.py
@@ -50,6 +50,8 @@ class ConfiguredFilter(object):
     def filter(self, record: logging.LogRecord) -> bool:
         """
         Get the level for the deepest parent, and filter appropriately.
+
+        :returns: If and only if the log should be done
         """
         level = ConfiguredFormatter.level_of_deepest_parent(
             self._levels, record.name)
@@ -80,6 +82,10 @@ class ConfiguredFormatter(logging.Formatter):
             conf: configparser.RawConfigParser) -> Dict[str, int]:
         """
         Create a dictionary of module names and logging levels.
+
+        This is based on the values if any found in the cfg files.
+
+        :returns: A dictionary of module names and logging levels.
         """
         # Construct the dictionary
         _levels: Dict[str, int] = {}
@@ -98,7 +104,7 @@ class ConfiguredFormatter(logging.Formatter):
     @staticmethod
     def deepest_parent(parents: KeysView[str], child: str) -> Optional[str]:
         """
-        Greediest match between child and parent.
+        :returns: Greediest match between child and parent.
         """
         # TODO: this can almost certainly be neater!
         # Repeatedly strip elements off the child until we match an item in
@@ -118,7 +124,8 @@ class ConfiguredFormatter(logging.Formatter):
     def level_of_deepest_parent(
             parents: Dict[str, int], child: str) -> Optional[int]:
         """
-        The logging level of the greediest match between child and parent.
+        :returns:
+           The logging level of the greediest match between child and parent.
         """
         # child = re.sub( r'^pacman103\.', '', child )
         parent = ConfiguredFormatter.deepest_parent(parents.keys(), child)
@@ -268,6 +275,9 @@ class FormatAdapter(logging.LoggerAdapter):
         logging call to insert contextual information. You can either
         manipulate the message itself, the keyword arguments or both.
         Return the message and *kwargs* modified (or not) to suit your needs.
+
+        :returns: the message and kwargs arguments in both the call
+           and the underlying logger.
         """
         return msg, {
             key: kwargs[key]

--- a/spinn_utilities/log_store.py
+++ b/spinn_utilities/log_store.py
@@ -51,5 +51,7 @@ class LogStore(object):
     def get_location(self) -> str:
         """
         Retrieves the location of the log store.
+
+        :returns: Path to the database holding the log store.
         """
         raise NotImplementedError

--- a/spinn_utilities/make_tools/file_converter.py
+++ b/spinn_utilities/make_tools/file_converter.py
@@ -325,7 +325,7 @@ class FileConverter(object):
         # Now check for the end of log command
         return self._process_line_in_log(dest_f, line_num, text[start_len:])
 
-    def quote_part(self, text: str) -> int:
+    def _quote_part(self, text: str) -> int:
         """
         Net count of double quotes in line.
 
@@ -333,7 +333,7 @@ class FileConverter(object):
         """
         return (text.count('"') - text.count('\\"')) % 2 > 0
 
-    def bracket_count(self, text: str) -> int:
+    def _bracket_count(self, text: str) -> int:
         """
         Net count of open brackets in line.
 
@@ -341,7 +341,7 @@ class FileConverter(object):
         """
         return (text.count('(') - text.count(')'))
 
-    def split_by_comma_plus(self, main: str, line_num: int) -> List[str]:
+    def _split_by_comma_plus(self, main: str, line_num: int) -> List[str]:
         """
         Split line by comma and partially parse.
 
@@ -373,14 +373,14 @@ class FileConverter(object):
                     parts.insert(i, new_part)
                 else:
                     # Not a String so look for function
-                    count = self.bracket_count(part)
+                    count = self._bracket_count(part)
                     if count > 0:
                         # More opening and closing brackets so in function
                         new_part = parts.pop(i)
                         # Keep combining parts until you find the last closing
                         while count > 0:
                             next_part = parts.pop(i)
-                            count += self.bracket_count(next_part)
+                            count += self._bracket_count(next_part)
                             new_part += "," + next_part
                         # Put the new part back into the list
                         parts.insert(i, new_part)
@@ -407,7 +407,7 @@ class FileConverter(object):
             raise UnexpectedCException(
                 f"Unexpected line {self._log_full} at "
                 f"{line_num} in {self._src}") from e
-        parts = self.split_by_comma_plus(main, line_num)
+        parts = self._split_by_comma_plus(main, line_num)
         original = parts[0]
 
         message_id = self._log_database.set_log_info(

--- a/spinn_utilities/make_tools/log_sqllite_database.py
+++ b/spinn_utilities/make_tools/log_sqllite_database.py
@@ -168,6 +168,7 @@ class LogSqlLiteDatabase(AbstractContextManager):
 
         :param src_path:
         :param dest_path:
+        :returns: The ID for this directory.
         """
         assert self._db is not None
         with self._db:
@@ -198,6 +199,7 @@ class LogSqlLiteDatabase(AbstractContextManager):
 
         :param directory_id:
         :param file_name:
+        :returns: The ID for this file
         """
         assert self._db is not None
         with self._db:
@@ -229,6 +231,7 @@ class LogSqlLiteDatabase(AbstractContextManager):
         :param line_num:
         :param original:
         :param file_id:
+        :returns: ID for this log message
         """
         assert self._db is not None
         with self._db:
@@ -268,6 +271,7 @@ class LogSqlLiteDatabase(AbstractContextManager):
         Gets the data needed to replace a short log back to the original.
 
         :param log_id: The int id as a String
+        :returns: log level, file name, line number and the original text
         """
         assert self._db is not None
         with self._db:
@@ -309,7 +313,7 @@ class LogSqlLiteDatabase(AbstractContextManager):
 
     def get_max_log_id(self) -> Optional[int]:
         """
-        Get the max id of any log message.
+        :returns: the max id of any log message, or None it there  none
         """
         assert self._db is not None
         with self._db:

--- a/spinn_utilities/make_tools/replacer.py
+++ b/spinn_utilities/make_tools/replacer.py
@@ -120,7 +120,8 @@ class Replacer(LogSqlLiteDatabase):
         """
         Apply the replacements to a short message.
 
-        :param short:
+        :param short: The short string as read of the machine
+        :returns: The message as it would if short codes where not used.
         """
         data = self._replace(short)
         if data is None:

--- a/spinn_utilities/ping.py
+++ b/spinn_utilities/ping.py
@@ -63,6 +63,7 @@ class Ping(object):
         :param ip_address:
             The IP address to ping. Hostnames can be used, but are not
             recommended.
+        :returns: True if and only if the ping worked when first tried.
         """
         if ip_address in Ping.unreachable:
             return False

--- a/spinn_utilities/ranged/abstract_list.py
+++ b/spinn_utilities/ranged/abstract_list.py
@@ -46,6 +46,8 @@ def _is_zero(value: Any) -> bool:
 def is_number(value: T) -> TypeGuard[float]:
     """
     Is the Value a simple integer or float?
+
+    :returns: True if the value is a Number
     """
     return isinstance(value, Number)
 

--- a/spinn_utilities/ranged/range_dictionary.py
+++ b/spinn_utilities/ranged/range_dictionary.py
@@ -214,6 +214,7 @@ class RangeDictionary(AbstractSized, AbstractDict[T], Generic[T]):
             Mainly intended by Views to access the data for one key directly.
 
         :param key: a key which must be present in the dict
+        :returns: The list like object for a single key
         """
         return self._value_lists[key]
 
@@ -233,6 +234,11 @@ class RangeDictionary(AbstractSized, AbstractDict[T], Generic[T]):
         Same as
         :py:meth:`iter_all_values`
         but limited to a collection of IDs and update-safe.
+
+        :return: If key is a str, this yields single objects.
+            If key is iterable (list, tuple, set, etc.) of str (or `None`),
+            yields dictionary objects
+
         """
         return (
             self.get_values_by_id(key=key, the_id=id_value)
@@ -281,6 +287,11 @@ class RangeDictionary(AbstractSized, AbstractDict[T], Generic[T]):
             Iterator[T], Iterator[Dict[str, T]]]:
         """
         Same as :py:meth:`iter_all_values` but limited to a simple slice.
+
+        :return: If key is a str, this yields single objects.
+            If key is iterable (list, tuple, set, etc.) of str (or `None`),
+            yields dictionary objects
+
         """
         if isinstance(key, str) and not update_safe:
             return self._value_lists[key].iter_by_slice(
@@ -310,6 +321,11 @@ class RangeDictionary(AbstractSized, AbstractDict[T], Generic[T]):
             Generator[T, None, None], Generator[Dict[str, T], None, None]]:
         """
         Same as :py:meth:`iter_all_values` but limited to a simple slice.
+
+        :return: If key is a str, this yields single objects.
+            If key is iterable (list, tuple, set, etc.) of str (or `None`),
+            yields dictionary objects
+
         """
         if update_safe:
             return self.update_safe_iter_all_values(key, ids)
@@ -452,6 +468,10 @@ class RangeDictionary(AbstractSized, AbstractDict[T], Generic[T]):
         :param key: see :py:meth:`iter_ranges` parameter key
         :param the_id:
             single ID which is the actual ID and not an index into IDs
+        :return: If key is a str, this yields single objects.
+            If key is iterable (list, tuple, set, etc.) of str (or `None`),
+            yields dictionary objects
+
         """
         if isinstance(key, str):
             return self._value_lists[key].iter_ranges_by_id(the_id=the_id)

--- a/spinn_utilities/ranged/ranged_list.py
+++ b/spinn_utilities/ranged/ranged_list.py
@@ -293,6 +293,7 @@ class RangedList(AbstractList[T], Generic[T]):
         Determines if the value should be treated as a list.
 
         :param value: The value to examine.
+        :returns: True if the value should be treated as a list
         """
         return self.listness_check(value)
 
@@ -305,6 +306,7 @@ class RangedList(AbstractList[T], Generic[T]):
             case :py:meth:`as_list` must also be extended.
 
         :param value: The value to examine.
+        :returns: True if the value should be treated as a list
         """
         # Assume any iterable is a list
         if callable(value):
@@ -551,6 +553,8 @@ class RangedList(AbstractList[T], Generic[T]):
 
         .. note::
             As this is a copy it will not reflect any updates.
+
+        :returns: A shallow copy of the list of ranges
         """
         if self._ranged_based:
             return list(self.__the_ranges)

--- a/spinn_utilities/ranged/slice_view.py
+++ b/spinn_utilities/ranged/slice_view.py
@@ -70,6 +70,7 @@ class _SliceView(AbstractView[T], Generic[T]):
         Iterate over the Values in a way that will work even between updates
 
         :param key:
+        :returns: The values for this key reflecting updates
         """
         ranged_list = self._range_dict.get_list(key)
         for the_id in self.ids():

--- a/spinn_utilities/require_subclass.py
+++ b/spinn_utilities/require_subclass.py
@@ -38,6 +38,7 @@ def require_subclass(required_class: Type) -> Callable[[Type], Type]:
     :param required_class:
         The class that the subclass of the decorated class must be an instance
         of (if that subclass is concrete).
+    :returns: The decorate method to be called later
     """
 
     # Beware! This is all deep shenanigans!

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -23,6 +23,8 @@ ERROR_NONE = 0
 ERROR_OTHER = ERROR_NONE + 1
 ERROR_FILE = ERROR_OTHER + 1
 
+UNITTESTS = os.sep + "unittests" + os.sep
+
 
 class DocsChecker(object):
     """
@@ -126,7 +128,7 @@ class DocsChecker(object):
         param_names = self.get_param_names(node)
         error = self._check_params_correct(param_names, docstring)
 
-        if node.name.startswith("_"):
+        if node.name.startswith("_") or UNITTESTS in self.__file_path:
             # these are not included by readthedocs so less important
             return error
 

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -261,6 +261,8 @@ class DocsChecker(object):
         Gets the names of the parameters found in the abstract syntax tree.
 
         These are the ones actually declared.
+
+        :returns: Names of all parameter including normal and kwargs ones
         """
         param_names: Set[str] = set()
         for arg in node.args.args:

--- a/spinn_utilities/timer.py
+++ b/spinn_utilities/timer.py
@@ -64,6 +64,8 @@ class Timer(object):
         """
         Describes how long has elapsed since the instance that the
         :py:meth:`start_timing` method was last called.
+
+        :returns: now - start_timing
         """
         time_now = perf_counter_ns()
         diff = time_now - (self._start_time or 0)

--- a/unittests/test_doc_checker.py
+++ b/unittests/test_doc_checker.py
@@ -34,7 +34,6 @@ class TestCfgChecker(unittest.TestCase):
         checker = DocsChecker(
             check_init=False,  # 30 errors in 18 files
             check_params=False,  # 78 errors in 27 files
-            check_returns=False,  # 69 errors in 25 files
             check_properties=False  # 3 errors in 3 files
         )
         checker.check_dir(repo_dir)

--- a/unittests/test_overrides.py
+++ b/unittests/test_overrides.py
@@ -23,11 +23,17 @@ BAD_DEFS = "Default arguments don't match super class method"
 
 class Base(object):
     def foo(self, x: int, y: int, z: int) -> List[int]:
-        """this is the doc"""
+        """this is the doc
+
+        :returns:
+        """
         return [x, y, z]
 
     def foodef(self, x: Any, y: int, z: Any = True) -> List[Any]:
-        """this is the doc"""
+        """this is the doc
+
+        :returns:
+        """
         return [x, y, z]
 
     @property
@@ -45,7 +51,10 @@ class Base(object):
 
     # This is bad as it does not define a return
     def bad(self, x: int, y: int, z: int):   # type: ignore[no-untyped-def]
-        """this is the doc"""
+        """this is the doc
+
+        :returns:
+        """
         return [x, y, z]
 
 
@@ -77,7 +86,10 @@ def test_doc_sub_no_extend() -> None:
     class Sub(Base):
         @overrides(Base.foo, extend_doc=False)
         def foo(self, x: int, y: int, z: int) -> List[int]:
-            """(abc)"""
+            """(abc)
+
+            :returns:
+            """
             return [z, y, x]
     assert Sub.foo.__doc__ == "(abc)"
 
@@ -86,7 +98,10 @@ def test_doc_sub_extend() -> None:
     class Sub(Base):
         @overrides(Base.foo, extend_doc=True)
         def foo(self, x: int, y: int, z: int) -> List[int]:
-            """(abc)"""
+            """(abc)
+
+            :returns:
+            """
             return [z, y, x]
     assert Sub.foo.__doc__ == "this is the doc(abc)"
 

--- a/unittests/test_overrides.py
+++ b/unittests/test_overrides.py
@@ -23,17 +23,11 @@ BAD_DEFS = "Default arguments don't match super class method"
 
 class Base(object):
     def foo(self, x: int, y: int, z: int) -> List[int]:
-        """this is the doc
-
-        :returns:
-        """
+        """this is the doc"""
         return [x, y, z]
 
     def foodef(self, x: Any, y: int, z: Any = True) -> List[Any]:
-        """this is the doc
-
-        :returns:
-        """
+        """this is the doc"""
         return [x, y, z]
 
     @property
@@ -51,10 +45,7 @@ class Base(object):
 
     # This is bad as it does not define a return
     def bad(self, x: int, y: int, z: int):   # type: ignore[no-untyped-def]
-        """this is the doc
-
-        :returns:
-        """
+        """this is the doc"""
         return [x, y, z]
 
 
@@ -71,7 +62,7 @@ def test_doc_no_sub_extend() -> None:
         @overrides(Base.foo, extend_doc=True)
         def foo(self, x: int, y: int, z: int) -> List[int]:
             return [z, y, x]
-    assert Sub.foo.__doc__ == "this is the doc\n\n:returns:\n"
+    assert Sub.foo.__doc__ == "this is the doc"
 
 
 def test_doc_no_sub_no_extend() -> None:
@@ -79,32 +70,25 @@ def test_doc_no_sub_no_extend() -> None:
         @overrides(Base.foo, extend_doc=False)
         def foo(self, x: int, y: int, z: int) -> List[int]:
             return [z, y, x]
-    assert Sub.foo.__doc__ == "this is the doc\n\n:returns:\n"
+    assert Sub.foo.__doc__ == "this is the doc"
 
 
 def test_doc_sub_no_extend() -> None:
     class Sub(Base):
         @overrides(Base.foo, extend_doc=False)
         def foo(self, x: int, y: int, z: int) -> List[int]:
-            """(abc)
-
-            :returns:
-            """
+            """(abc)"""
             return [z, y, x]
-    assert Sub.foo.__doc__ == "(abc)\n\n:returns:\n"
+    assert Sub.foo.__doc__ == "(abc)"
 
 
 def test_doc_sub_extend() -> None:
     class Sub(Base):
         @overrides(Base.foo, extend_doc=True)
         def foo(self, x: int, y: int, z: int) -> List[int]:
-            """(abc)
-
-            :returns:
-            """
+            """(abc)"""
             return [z, y, x]
-    assert (Sub.foo.__doc__ ==
-            "this is the doc\n\n:returns:\n(abc)\n\n:returns:\n")
+    assert Sub.foo.__doc__ == "this is the doc(abc)"
 
 
 def test_changes_params_defaults() -> None:

--- a/unittests/test_overrides.py
+++ b/unittests/test_overrides.py
@@ -71,7 +71,7 @@ def test_doc_no_sub_extend() -> None:
         @overrides(Base.foo, extend_doc=True)
         def foo(self, x: int, y: int, z: int) -> List[int]:
             return [z, y, x]
-    assert Sub.foo.__doc__ == "this is the doc"
+    assert Sub.foo.__doc__ == "this is the doc\n\n:returns:\n"
 
 
 def test_doc_no_sub_no_extend() -> None:
@@ -79,7 +79,7 @@ def test_doc_no_sub_no_extend() -> None:
         @overrides(Base.foo, extend_doc=False)
         def foo(self, x: int, y: int, z: int) -> List[int]:
             return [z, y, x]
-    assert Sub.foo.__doc__ == "this is the doc"
+    assert Sub.foo.__doc__ == "this is the doc\n\n:returns:\n"
 
 
 def test_doc_sub_no_extend() -> None:
@@ -91,7 +91,7 @@ def test_doc_sub_no_extend() -> None:
             :returns:
             """
             return [z, y, x]
-    assert Sub.foo.__doc__ == "(abc)"
+    assert Sub.foo.__doc__ == "(abc)\n\n:returns:\n"
 
 
 def test_doc_sub_extend() -> None:
@@ -103,7 +103,8 @@ def test_doc_sub_extend() -> None:
             :returns:
             """
             return [z, y, x]
-    assert Sub.foo.__doc__ == "this is the doc(abc)"
+    assert (Sub.foo.__doc__ ==
+            "this is the doc\n\n:returns:\n(abc)\n\n:returns:\n")
 
 
 def test_changes_params_defaults() -> None:


### PR DESCRIPTION
Adds return documentation

doc checker will skip some checks on unittests
- only checks prams are correct and not typed

classproperty renamed a variable

some methods converted to protected