### PR TITLE
Param docs

### DIFF
--- a/spinn_utilities/config_holder.py
+++ b/spinn_utilities/config_holder.py
@@ -370,6 +370,9 @@ def get_report_path(
     :param option: cfg option name
     :param section: cfg section. Needed if not Reports
     :param n_run: If provided will be used instead of the current run number
+    :param is_dir:
+        When true will make sure this path exists as a directory.
+        When False will make sure the parent directory is exists.
     :return: An unchecked absolute path to the file or directory
     """
     path = get_config_str(section, option)

--- a/spinn_utilities/executable_finder.py
+++ b/spinn_utilities/executable_finder.py
@@ -102,7 +102,7 @@ class ExecutableFinder(object):
 
     def get_executable_paths(self, executable_names: str) -> List[str]:
         """
-        Finds each executables within the set of folders.
+        Finds each executable within the set of folders.
 
         The names are assumed to be comma separated
         The set of folders is searched sequentially

--- a/spinn_utilities/package_loader.py
+++ b/spinn_utilities/package_loader.py
@@ -28,6 +28,7 @@ def all_modules(directory: str, prefix: str,
 
     :param directory: path to check for python files
     :param prefix: package prefix top add to the file name
+    :param remove_pyc_files: True if ``.pyc`` files should be deleted
     :return: set of python package names
     """
     results = set()

--- a/spinn_utilities/ranged/ranged_list.py
+++ b/spinn_utilities/ranged/ranged_list.py
@@ -322,7 +322,13 @@ class RangedList(AbstractList[T], Generic[T]):
             This method can be extended to add other conversions to list in
             which case :py:meth:`listness_check` must also be extended.
 
-        :param value:
+        :param value: Either a method that takes an int as input
+            or something that can have the list method applied.
+        :param size:
+            The number of elements to put in the list.
+        :param ids:
+            A list of IDs to call the function for or ``None`` to use the size.
+            Only used if the value is a callable.
         :return: value as a list
         :raises Exception: if the number of values and the size do not match
         """
@@ -343,7 +349,7 @@ class RangedList(AbstractList[T], Generic[T]):
         .. note::
             Does not change the default.
 
-        :param value: new value
+        :param value: new value(s)
         :param use_list_as_value: True if the value to be set *is* a list
         """
 
@@ -430,7 +436,8 @@ class RangedList(AbstractList[T], Generic[T]):
 
         :param slice_start: Start of the range
         :param slice_stop: Exclusive end of the range
-        :param value: The value to save
+        :param value: The value(s) to save
+        :param use_list_as_value: True if the value to be set *is* a list
         """
         slice_start, slice_stop = self._check_slice_in_range(
             slice_start, slice_stop)
@@ -526,7 +533,8 @@ class RangedList(AbstractList[T], Generic[T]):
         Support for the ``list[x] =`` format.
 
         :param selector: A single ID, a slice of IDs or a list of IDs
-        :param value:
+        :param value: new value(s)
+        :param use_list_as_value: True if the value to be set *is* a list
         """
         if selector is None:
             self.set_value(value, use_list_as_value=use_list_as_value)

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -272,6 +272,10 @@ class DocsChecker(object):
         if node.args.kwarg:
             param_names.add(node.args.kwarg.arg)
 
+        if "self" in param_names:
+            param_names.remove("self")
+        if "cls" in param_names:
+            param_names.remove("cls")
         return param_names
 
     def check_no_errors(self) -> None:

--- a/unittests/test_doc_checker.py
+++ b/unittests/test_doc_checker.py
@@ -33,7 +33,6 @@ class TestCfgChecker(unittest.TestCase):
         repo_dir = os.path.dirname(unittest_dir)
         checker = DocsChecker(
             check_init=False,  # 30 errors in 18 files
-            check_params=False,  # 78 errors in 27 files
             check_returns=False,  # 69 errors in 25 files
             check_properties=False  # 3 errors in 3 files
         )


### PR DESCRIPTION
small update to doc checker to not consider self or cls params that need docs

adds missing params to docs where some but not all params are documented. 