### PR TITLE
Docs fixes

### DIFF
--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -39,13 +39,15 @@ class DocsChecker(object):
     __slots__ = [
         "__check_init", "__check_short", "__check_params",
         "__check_properties", "__check_returns",
+        "__check_types_in_docs",
         "__error_level", "__file_path", "__file_errors",
         "__functions_errors"]
 
     def __init__(
             self, *, check_init: bool = True, check_short: bool = True,
             check_params: bool = True, check_properties: bool = True,
-            check_returns: bool = True) -> None:
+            check_returns: bool = True,
+            check_types_in_docs: bool = True) -> None:
         """
         Sets up the doc checker.
 
@@ -68,8 +70,11 @@ class DocsChecker(object):
             They should not have a return annotation
         :param check_returns: Flag to trigger checking of return annotations
             when not a property
+        :param check_types_in_docs:
+            Flag to trigger checking that docstring have no types
         """
         self.__error_level = ERROR_NONE
+        self.__check_types_in_docs = check_types_in_docs
         self.__check_init = check_init
         self.__check_params = check_params
         self.__check_properties = check_properties
@@ -266,7 +271,8 @@ class DocsChecker(object):
             if param.arg_name not in param_names:
                 error += f"{param.arg_name}: is incorrect "
             elif param.type_name:
-                error += f"{param.arg_name}: is typed "
+                if self.__check_types_in_docs:
+                    error += f"{param.arg_name}: is typed "
         return error
 
     def _check_params_all_or_none(
@@ -288,9 +294,10 @@ class DocsChecker(object):
         """
         error = ""
 
-        for key in [":type", ":rtype"]:
-            if key in docs:
-                error += f"found {key} "
+        if self.__check_types_in_docs:
+            for key in [":type", ":rtype"]:
+                if key in docs:
+                    error += f"found {key} "
         index = sys.maxsize
         for key in [":param", ":return", ":raises"]:
             if key in docs:

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -149,7 +149,9 @@ class DocsChecker(object):
             if self.is_property(node):
                 if self.__check_properties:
                     if docstring.short_description is None:
-                        error += "No short description provided."
+                        # docstring_parser can not handle these RTD can
+                        if not docs.startswith(":math:"):
+                            error += "No short description provided."
                     if len(docstring.many_returns) > 0:
                         error += "Unexpected returns"
                         if self.__check_params:

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -149,7 +149,8 @@ class DocsChecker(object):
             if self.is_property(node):
                 if self.__check_properties:
                     if docstring.short_description is None:
-                        # docstring_parser can not handle these RTD can
+                        # docstring_parser can not handle  these
+                        # Read The Docs can
                         if not docs.startswith(":math:"):
                             error += "No short description provided."
                     if len(docstring.many_returns) > 0:

--- a/spinn_utilities/testing/docs_checker.py
+++ b/spinn_utilities/testing/docs_checker.py
@@ -71,7 +71,7 @@ class DocsChecker(object):
         :param check_returns: Flag to trigger checking of return annotations
             when not a property
         :param check_types_in_docs:
-            Flag to trigger checking that docstring have no types
+            Flag to trigger checking that doc-string have no types
         """
         self.__error_level = ERROR_NONE
         self.__check_types_in_docs = check_types_in_docs


### PR DESCRIPTION
Short docs in the format :math:`E_{{rev}_e}` do not work in docstring_parser

They do in readthedocs

See 
https://github.com/SpiNNakerManchester/sPyNNaker/blob/master/spynnaker/pyNN/models/neuron/input_types/input_type_conductance.py
and
https://spynnaker.readthedocs.io/en/master/spynnaker.pyNN.models.neuron.input_types/#spynnaker.pyNN.models.neuron.input_types.InputTypeConductance