### PR TITLE
check_executable_path without logging use

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -700,7 +700,7 @@ class UtilsDataView(object):
         Unlike get_executable_path(s) does not log the path as used.
 
         :param executable_name: The name of the executable to find
-        :return: True if found. Ie get_executable_path would return work
+        :return: True if found. Then get_executable_path will work
         """
         return cls.__data._executable_finder.check_executable_path(
             executable_name)

--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -693,6 +693,19 @@ class UtilsDataView(object):
                              f"Found {os.listdir(search_path)}")
 
     @classmethod
+    def check_executable_path(cls, executable_name: str) -> bool:
+        """
+        Checks for an executable within the set of folders.
+
+        Unlike get_executable_path(s) does not log the path as used.
+
+        :param executable_name: The name of the executable to find
+        :return: True if found. Ie get_executable_path would return work
+        """
+        return cls.__data._executable_finder.check_executable_path(
+            executable_name)
+
+    @classmethod
     def get_executable_path(cls, executable_name: str) -> str:
         """
         Finds an executable within the set of folders. The set of folders

--- a/spinn_utilities/executable_finder.py
+++ b/spinn_utilities/executable_finder.py
@@ -83,7 +83,7 @@ class ExecutableFinder(object):
         Unlike get_executable_path(s) does not log the path as used.
 
         :param executable_name: The name of the executable to find
-        :return: True if found. Ie get_executable_path would return work
+        :return: True if found. Then get_executable_path will work
         """
         # Loop through search paths
         for path in self._binary_search_paths:

--- a/spinn_utilities/executable_finder.py
+++ b/spinn_utilities/executable_finder.py
@@ -76,6 +76,25 @@ class ExecutableFinder(object):
         """
         return " : ".join(self._binary_search_paths)
 
+    def check_executable_path(self, executable_name: str) -> bool:
+        """
+        Checks for an executable within the set of folders.
+
+        Unlike get_executable_path(s) does not log the path as used.
+
+        :param executable_name: The name of the executable to find
+        :return: True if found. Ie get_executable_path would return work
+        """
+        # Loop through search paths
+        for path in self._binary_search_paths:
+            # Rebuild filename
+            potential_filename = os.path.join(path, executable_name)
+
+            # If this filename exists, return it
+            if os.path.isfile(potential_filename):
+                return True
+        return False
+
     def get_executable_path(self, executable_name: str) -> str:
         """
         Finds an executable within the set of folders. The set of folders


### PR DESCRIPTION
Add a function to check an executable exists without recording it as used.
