### PR TITLE
typing fixes

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -19,7 +19,7 @@ name: Python Actions
 on: [push]
 jobs:
   call:
-    uses: SpiNNakerManchester/SupportScripts/.github/workflows/python_checks.yml@main
+    uses: SpiNNakerManchester/SupportScripts/.github/workflows/python_checks.yml@mypy2
     with:
       dependencies:
       test-directories: unittests

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -19,7 +19,7 @@ name: Python Actions
 on: [push]
 jobs:
   call:
-    uses: SpiNNakerManchester/SupportScripts/.github/workflows/python_checks.yml@mypy2
+    uses: SpiNNakerManchester/SupportScripts/.github/workflows/python_checks.yml@main
     with:
       dependencies:
       test-directories: unittests

--- a/spinn_utilities/configs/camel_case_config_parser.py
+++ b/spinn_utilities/configs/camel_case_config_parser.py
@@ -15,7 +15,7 @@ import os
 
 from collections.abc import Iterable
 import configparser
-from typing import List, Optional, TYPE_CHECKING, Union
+from typing import List, Optional, Union
 
 
 NONES = ("none", )
@@ -23,12 +23,8 @@ TRUES = ('y', 'yes', 't', 'true', 'on', '1')
 FALSES = ('n', 'no', 'f', 'false', 'off', '0')
 
 # Type support
-if TYPE_CHECKING:
-    _Path = Union[Union[str, bytes, os.PathLike],
-                  Iterable[Union[str, bytes, os.PathLike]]]
-else:
-    # Python 3.8 does not support above typing
-    _Path = str
+_Path = Union[Union[str, bytes, os.PathLike],
+              Iterable[Union[str, bytes, os.PathLike]]]
 
 
 def optionxform(optionstr: str) -> str:
@@ -65,8 +61,9 @@ class TypedConfigParser(configparser.RawConfigParser):
         """
         return optionstr
 
-    def read(self, filenames: _Path,
-             encoding: Optional[str] = None) -> List[str]:
+    #  typing in super class heavily overloaded and hard to replicate
+    def read(self, filenames,  # type: ignore[no-untyped-def]
+             encoding: Optional[str] = None):
         """
         Read and parse a filename or a list of filenames.
 

--- a/spinn_utilities/logger_utils.py
+++ b/spinn_utilities/logger_utils.py
@@ -14,7 +14,7 @@
 
 from spinn_utilities.log import FormatAdapter
 
-_already_issued = set()
+_already_issued: set[str] = set()
 
 
 def warn_once(logger: FormatAdapter, msg: str) -> None:


### PR DESCRIPTION
adaptions form mypy 2.0.0

note camel_case_config_parser.py read super is typed as

@overload
def [AnyStr: (str, bytes)] read(self, filenames: AnyStr | PathLike[AnyStr], encoding: str | None = ...) -> list[AnyStr]

@overload
def read(self, filenames: Iterable[str | PathLike[str]], encoding: str | None = ...) -> list[str]

@overload
def read(self, filenames: Iterable[bytes | PathLike[bytes]], encoding: str | None = ...) -> list[bytes]

@overload
def read(self, filenames: Iterable[str | bytes | PathLike[str] | PathLike[bytes]], encoding: str | None = ...) -> list[str | bytes]

Attempt to replicate it failed and in the end not considered worth it