### PR TITLE
only log the database error once

### DIFF
--- a/spinn_utilities/data/utils_data_view.py
+++ b/spinn_utilities/data/utils_data_view.py
@@ -24,6 +24,7 @@ from spinn_utilities.exceptions import (
     SimulatorShutdownException, UnexpectedStateChange)
 from spinn_utilities.executable_finder import ExecutableFinder
 from spinn_utilities.log import FormatAdapter
+from spinn_utilities import logger_utils
 from spinn_utilities.make_tools.log_sqllite_database import LogSqlLiteDatabase
 from .data_status import DataStatus
 from .reset_status import ResetStatus
@@ -783,7 +784,8 @@ class UtilsDataView(object):
             if 'RUNNER_ENVIRONMENT' in os.environ:
                 raise ValueError(f"No logs database found for {database_key=}")
             else:
-                logger.error(f"No logs database found for {database_key=}")
+                logger_utils.error_once(
+                    logger, f"No logs database found for {database_key=}")
                 return None
         return cls.__data._log_database_paths[database_key]
 


### PR DESCRIPTION
no need for this log to be repeated.

Note: In github actions it raises an error 

So this is only for users.
But also why the test https://github.com/SpiNNakerManchester/SpiNNUtils/blob/f7e0e07c21dcceeda26544b3ecbfc1d347643f70/unittests/data/test_utils_data.py#L1134  
only failed locally as well